### PR TITLE
Allow to specify a batch size for RandomWordsEQOracle

### DIFF
--- a/eqtests/basic-eqtests/src/main/java/de/learnlib/eqtests/basic/RandomWordsEQOracle.java
+++ b/eqtests/basic-eqtests/src/main/java/de/learnlib/eqtests/basic/RandomWordsEQOracle.java
@@ -112,11 +112,11 @@ public class RandomWordsEQOracle<I, O, A extends OutputAutomaton<?, I, ?, O>> im
 			}
 
 			final DefaultQuery<I, O> query = new DefaultQuery<>(testtrace.toWord());
-
-			final boolean batchFilled = queryBatch.size() >= batchSize - 1;
+			queryBatch.add(query);
+			
+			final boolean batchFilled = queryBatch.size() >= batchSize;
 			final boolean maxTestsReached = i >= maxTests - 1;
 
-			queryBatch.add(query);
 			if(batchFilled || maxTestsReached) {
 				// query oracle
 				oracle.processQueries(queryBatch);


### PR DESCRIPTION
We need to perform parallel executions in the random EQ oracle. In order to this, we extended the `RandomWordsEQOracle` by a `batchSize` parameter. Using a `ParallelOracle` together with this oracle will result in a parallel execution.
