### PR TITLE
Fixes a bug in the TTT algorithm

### DIFF
--- a/algorithms/ttt/src/main/java/de/learnlib/algorithms/ttt/mealy/TTTLearnerMealy.java
+++ b/algorithms/ttt/src/main/java/de/learnlib/algorithms/ttt/mealy/TTTLearnerMealy.java
@@ -118,10 +118,10 @@ public class TTTLearnerMealy<I, O> extends
 	
 	@Override
 	@SuppressWarnings("unchecked")
-	public boolean refineHypothesis(DefaultQuery<I,Word<O>> ceQuery) {
+	public boolean refineHypothesisSingle(DefaultQuery<I,Word<O>> ceQuery) {
 		DefaultQuery<I,Word<O>> shortenedCeQuery = MealyUtil.shortenCounterExample((TTTHypothesisMealy<I, O>) hypothesis, ceQuery);
 		if (shortenedCeQuery != null) {
-			return super.refineHypothesis(shortenedCeQuery);
+			return super.refineHypothesisSingle(shortenedCeQuery);
 		}
 		return false;
 	}


### PR DESCRIPTION
TTT now always uses a shortened counter example in each refinement,
which is required by the counter example analyzers.

I tested it with some of our own benchmarks.
Furthermore, all tests in learnlib succeeded.