### PR TITLE
make NLStar observation table readable

### DIFF
--- a/algorithms/active/nlstar/src/main/java/de/learnlib/algorithms/nlstar/NLStarLearner.java
+++ b/algorithms/active/nlstar/src/main/java/de/learnlib/algorithms/nlstar/NLStarLearner.java
@@ -231,4 +231,8 @@ public class NLStarLearner<I> implements NFALearner<I> {
         return hypothesis;
     }
 
+    public ObservationTable<I> getObservationTable() {
+        return table;
+    }
+
 }


### PR DESCRIPTION
This is useful for the visualization of the algorithm. And it gives access to the prefixes and suffices.

keep in mind that this is not compatible with LStar tables