### PR TITLE
Drop guava

### DIFF
--- a/algorithms/active/aaar/pom.xml
+++ b/algorithms/active/aaar/pom.xml
@@ -43,11 +43,6 @@ limitations under the License.
 
         <!-- external -->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>net.automatalib</groupId>
             <artifactId>automata-api</artifactId>
         </dependency>

--- a/algorithms/active/aaar/src/main/java/de/learnlib/algorithm/aaar/explicit/AbstractExplicitAAARLearner.java
+++ b/algorithms/active/aaar/src/main/java/de/learnlib/algorithm/aaar/explicit/AbstractExplicitAAARLearner.java
@@ -17,12 +17,12 @@ package de.learnlib.algorithm.aaar.explicit;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
-import com.google.common.collect.Maps;
 import de.learnlib.algorithm.LearnerConstructor;
 import de.learnlib.algorithm.LearningAlgorithm;
 import de.learnlib.algorithm.aaar.AbstractAAARLearner;
@@ -34,6 +34,7 @@ import de.learnlib.oracle.MembershipOracle;
 import net.automatalib.alphabet.Alphabet;
 import net.automatalib.alphabet.SupportsGrowingAlphabet;
 import net.automatalib.alphabet.impl.Alphabets;
+import net.automatalib.common.util.HashUtil;
 
 /**
  * An "explicit" refinement of the {@link AbstractAAARLearner}. This implementation requires a prior partition of (all)
@@ -83,7 +84,8 @@ public abstract class AbstractExplicitAAARLearner<L extends LearningAlgorithm<CM
         super(learnerConstructor, oracle);
 
         this.explicitInitialAbstraction = explicitInitialAbstraction;
-        this.trees = Maps.newHashMapWithExpectedSize(explicitInitialAbstraction.getInitialAbstracts().size());
+        this.trees =
+                new HashMap<>(HashUtil.capacity(explicitInitialAbstraction.getInitialAbstracts().size()));
 
         for (AI a : explicitInitialAbstraction.getInitialAbstracts()) {
             final CI rep = explicitInitialAbstraction.getRepresentative(a);

--- a/algorithms/active/aaar/src/main/java/de/learnlib/algorithm/aaar/explicit/AbstractExplicitAAARLearner.java
+++ b/algorithms/active/aaar/src/main/java/de/learnlib/algorithm/aaar/explicit/AbstractExplicitAAARLearner.java
@@ -84,8 +84,7 @@ public abstract class AbstractExplicitAAARLearner<L extends LearningAlgorithm<CM
         super(learnerConstructor, oracle);
 
         this.explicitInitialAbstraction = explicitInitialAbstraction;
-        this.trees =
-                new HashMap<>(HashUtil.capacity(explicitInitialAbstraction.getInitialAbstracts().size()));
+        this.trees = new HashMap<>(HashUtil.capacity(explicitInitialAbstraction.getInitialAbstracts().size()));
 
         for (AI a : explicitInitialAbstraction.getInitialAbstracts()) {
             final CI rep = explicitInitialAbstraction.getRepresentative(a);

--- a/algorithms/active/aaar/src/main/java/module-info.java
+++ b/algorithms/active/aaar/src/main/java/module-info.java
@@ -30,7 +30,6 @@
  */
 open module de.learnlib.algorithm.aaar {
 
-    requires com.google.common;
     requires de.learnlib.api;
     requires net.automatalib.api;
     requires net.automatalib.common.util;

--- a/algorithms/active/aaar/src/test/java/de/learnlib/algorithm/aaar/AbstractAAARTest.java
+++ b/algorithms/active/aaar/src/test/java/de/learnlib/algorithm/aaar/AbstractAAARTest.java
@@ -15,10 +15,9 @@
  */
 package de.learnlib.algorithm.aaar;
 
-import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 
-import com.google.common.collect.Lists;
 import de.learnlib.algorithm.LearningAlgorithm;
 import de.learnlib.oracle.MembershipOracle;
 import de.learnlib.oracle.equivalence.SampleSetEQOracle;
@@ -28,6 +27,7 @@ import de.learnlib.util.Experiment;
 import net.automatalib.alphabet.Alphabet;
 import net.automatalib.automaton.UniversalDeterministicAutomaton;
 import net.automatalib.automaton.concept.SuffixOutput;
+import net.automatalib.common.util.collection.IteratorUtil;
 import net.automatalib.util.automaton.Automata;
 import net.automatalib.util.automaton.conformance.WpMethodTestsIterator;
 import net.automatalib.word.Word;
@@ -50,7 +50,7 @@ public abstract class AbstractAAARTest<L extends AbstractAAARLearner<?, A, A, I,
     public void testAbstractHypothesisEquivalence() {
 
         final WpMethodTestsIterator<I> iter = new WpMethodTestsIterator<>(automaton, alphabet);
-        final ArrayList<Word<I>> testCases = Lists.newArrayList(iter);
+        final List<Word<I>> testCases = IteratorUtil.list(iter);
 
         final SampleSetEQOracle<I, D> eqo = new SampleSetEQOracle<>(false);
         eqo.addAll(new SimulatorOracle<>(automaton), testCases);

--- a/algorithms/active/aaar/src/test/java/de/learnlib/algorithm/aaar/generic/GenericAAARLearnerDFATest.java
+++ b/algorithms/active/aaar/src/test/java/de/learnlib/algorithm/aaar/generic/GenericAAARLearnerDFATest.java
@@ -21,7 +21,6 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.util.function.Function;
 
-import com.google.common.io.CharStreams;
 import de.learnlib.algorithm.aaar.AAARTestUtil;
 import de.learnlib.algorithm.aaar.AbstractAAARTest;
 import de.learnlib.algorithm.aaar.abstraction.AbstractAbstractionTree;
@@ -59,7 +58,7 @@ public class GenericAAARLearnerDFATest
         try (Reader r = IOUtil.asBufferedUTF8Reader(GenericAAARLearnerDFATest.class.getResourceAsStream("/tree_dfa.dot"));
              Writer w = new StringWriter()) {
 
-            final String expected = CharStreams.toString(r);
+            final String expected = IOUtil.toString(r);
             GraphDOT.write((GraphViewable) tree, w);
 
             Assert.assertEquals(w.toString(), expected);

--- a/algorithms/active/aaar/src/test/java/de/learnlib/algorithm/aaar/generic/GenericAAARLearnerMealyTest.java
+++ b/algorithms/active/aaar/src/test/java/de/learnlib/algorithm/aaar/generic/GenericAAARLearnerMealyTest.java
@@ -21,7 +21,6 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.util.function.Function;
 
-import com.google.common.io.CharStreams;
 import de.learnlib.algorithm.aaar.AAARTestUtil;
 import de.learnlib.algorithm.aaar.AbstractAAARTest;
 import de.learnlib.algorithm.aaar.abstraction.AbstractAbstractionTree;
@@ -63,7 +62,7 @@ public class GenericAAARLearnerMealyTest
                 "/tree_mealy.dot"));
              Writer w = new StringWriter()) {
 
-            final String expected = CharStreams.toString(r);
+            final String expected = IOUtil.toString(r);
             GraphDOT.write((GraphViewable) tree, w);
 
             Assert.assertEquals(w.toString(), expected);

--- a/algorithms/active/aaar/src/test/java/de/learnlib/algorithm/aaar/generic/GenericAAARLearnerMooreTest.java
+++ b/algorithms/active/aaar/src/test/java/de/learnlib/algorithm/aaar/generic/GenericAAARLearnerMooreTest.java
@@ -22,7 +22,6 @@ import java.io.Writer;
 import java.util.Random;
 import java.util.function.Function;
 
-import com.google.common.io.CharStreams;
 import de.learnlib.algorithm.LearningAlgorithm.MooreLearner;
 import de.learnlib.algorithm.aaar.AAARTestUtil;
 import de.learnlib.algorithm.aaar.AbstractAAARTest;
@@ -76,7 +75,7 @@ public class GenericAAARLearnerMooreTest
                 "/tree_moore.dot"));
              Writer w = new StringWriter()) {
 
-            final String expected = CharStreams.toString(r);
+            final String expected = IOUtil.toString(r);
             GraphDOT.write((GraphViewable) tree, w);
 
             Assert.assertEquals(w.toString(), expected);

--- a/algorithms/active/adt/pom.xml
+++ b/algorithms/active/adt/pom.xml
@@ -51,11 +51,6 @@ limitations under the License.
 
         <!-- external -->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>net.automatalib</groupId>
             <artifactId>automata-api</artifactId>
         </dependency>

--- a/algorithms/active/adt/src/main/java/de/learnlib/algorithm/adt/config/model/replacer/ExhaustiveReplacer.java
+++ b/algorithms/active/adt/src/main/java/de/learnlib/algorithm/adt/config/model/replacer/ExhaustiveReplacer.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Set;
 
-import com.google.common.collect.Sets;
 import de.learnlib.algorithm.adt.adt.ADT;
 import de.learnlib.algorithm.adt.adt.ADTNode;
 import de.learnlib.algorithm.adt.api.SubtreeReplacer;
@@ -31,6 +30,7 @@ import de.learnlib.algorithm.adt.model.ReplacementResult;
 import de.learnlib.algorithm.adt.util.ADTUtil;
 import net.automatalib.alphabet.Alphabet;
 import net.automatalib.automaton.transducer.MealyMachine;
+import net.automatalib.common.util.HashUtil;
 
 public class ExhaustiveReplacer implements SubtreeReplacer {
 
@@ -62,7 +62,7 @@ public class ExhaustiveReplacer implements SubtreeReplacer {
         final PriorityQueue<Set<S>> queue = new PriorityQueue<>(candidates.size(), Comparator.comparingInt(Set::size));
         for (ADTNode<S, I, O> node : candidates) {
             final Set<ADTNode<S, I, O>> leaves = ADTUtil.collectLeaves(node);
-            final Set<S> set = Sets.newHashSetWithExpectedSize(leaves.size());
+            final Set<S> set = new HashSet<>(HashUtil.capacity(leaves.size()));
 
             for (ADTNode<S, I, O> l : leaves) {
                 set.add(l.getHypothesisState());

--- a/algorithms/active/adt/src/main/java/module-info.java
+++ b/algorithms/active/adt/src/main/java/module-info.java
@@ -30,7 +30,6 @@
  */
 open module de.learnlib.algorithm.adt {
 
-    requires com.google.common;
     requires de.learnlib.api;
     requires de.learnlib.common.counterexample;
     requires de.learnlib.common.util;

--- a/algorithms/active/dhc/pom.xml
+++ b/algorithms/active/dhc/pom.xml
@@ -47,11 +47,6 @@ limitations under the License.
 
         <!-- external -->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>net.automatalib</groupId>
             <artifactId>automata-api</artifactId>
         </dependency>

--- a/algorithms/active/dhc/src/main/java/de/learnlib/algorithm/dhc/mealy/MealyDHC.java
+++ b/algorithms/active/dhc/src/main/java/de/learnlib/algorithm/dhc/mealy/MealyDHC.java
@@ -27,9 +27,6 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 
-import com.google.common.collect.Interner;
-import com.google.common.collect.Interners;
-import com.google.common.collect.Sets;
 import de.learnlib.AccessSequenceTransformer;
 import de.learnlib.Resumable;
 import de.learnlib.algorithm.GlobalSuffixLearner.GlobalSuffixLearnerMealy;
@@ -42,6 +39,7 @@ import de.learnlib.tooling.annotation.builder.GenerateBuilder;
 import net.automatalib.alphabet.Alphabet;
 import net.automatalib.alphabet.SupportsGrowingAlphabet;
 import net.automatalib.automaton.transducer.impl.CompactMealy;
+import net.automatalib.common.util.HashUtil;
 import net.automatalib.common.util.mapping.MapMapping;
 import net.automatalib.common.util.mapping.MutableMapping;
 import net.automatalib.word.Word;
@@ -157,8 +155,6 @@ public class MealyDHC<I, O> implements MealyLearner<I, O>,
         // first element to be explored represents the initial state with no predecessor
         queue.add(new QueueElement<>(null, null, null, null));
 
-        Interner<Word<O>> deduplicator = Interners.newStrongInterner();
-
         while (!queue.isEmpty()) {
             // get element to be explored from queue
             @SuppressWarnings("nullness") // false positive https://github.com/typetools/checker-framework/issues/399
@@ -179,7 +175,7 @@ public class MealyDHC<I, O> implements MealyLearner<I, O>,
             // assemble output signature
             List<Word<O>> sig = new ArrayList<>(splitters.size());
             for (DefaultQuery<I, Word<O>> query : queries) {
-                sig.add(deduplicator.intern(query.getOutput()));
+                sig.add(query.getOutput());
             }
 
             Integer sibling = signatures.get(sig);
@@ -257,7 +253,7 @@ public class MealyDHC<I, O> implements MealyLearner<I, O>,
         if (!this.splitters.contains(Word.fromLetter(symbol))) {
             final Iterator<Word<I>> splitterIterator = this.splitters.iterator();
             final LinkedHashSet<Word<I>> newSplitters =
-                    Sets.newLinkedHashSetWithExpectedSize(this.splitters.size() + 1);
+                    new LinkedHashSet<>(HashUtil.capacity(this.splitters.size() + 1));
 
             // see initial initialization of the splitters
             for (int i = 0; i < this.alphabet.size() - 1; i++) {

--- a/algorithms/active/dhc/src/main/java/de/learnlib/algorithm/dhc/mealy/MealyDHCState.java
+++ b/algorithms/active/dhc/src/main/java/de/learnlib/algorithm/dhc/mealy/MealyDHCState.java
@@ -15,11 +15,12 @@
  */
 package de.learnlib.algorithm.dhc.mealy;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import com.google.common.collect.Maps;
 import net.automatalib.automaton.transducer.impl.CompactMealy;
+import net.automatalib.common.util.HashUtil;
 import net.automatalib.common.util.mapping.MutableMapping;
 import net.automatalib.word.Word;
 
@@ -42,7 +43,7 @@ public class MealyDHCState<I, O> {
                   MutableMapping<Integer, MealyDHC.QueueElement<I, O>> accessSequences) {
         this.splitters = splitters;
         this.hypothesis = hypothesis;
-        this.accessSequences = Maps.newHashMapWithExpectedSize(hypothesis.size());
+        this.accessSequences = new HashMap<>(HashUtil.capacity(hypothesis.size()));
 
         for (Integer s : hypothesis.getStates()) {
             final MealyDHC.QueueElement<I, O> elem = accessSequences.get(s);

--- a/algorithms/active/dhc/src/main/java/module-info.java
+++ b/algorithms/active/dhc/src/main/java/module-info.java
@@ -30,7 +30,6 @@
  */
 open module de.learnlib.algorithm.dhc {
 
-    requires com.google.common;
     requires de.learnlib.api;
     requires de.learnlib.common.counterexample;
     requires net.automatalib.api;

--- a/algorithms/active/kearns-vazirani/pom.xml
+++ b/algorithms/active/kearns-vazirani/pom.xml
@@ -59,7 +59,7 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>net.automatalib</groupId>
-            <artifactId>automata-commons-smartcollections</artifactId>
+            <artifactId>automata-commons-util</artifactId>
         </dependency>
         <dependency>
             <groupId>net.automatalib</groupId>

--- a/algorithms/active/kearns-vazirani/src/main/java/de/learnlib/algorithm/kv/dfa/KearnsVaziraniDFA.java
+++ b/algorithms/active/kearns-vazirani/src/main/java/de/learnlib/algorithm/kv/dfa/KearnsVaziraniDFA.java
@@ -40,7 +40,7 @@ import net.automatalib.alphabet.Alphabet;
 import net.automatalib.alphabet.SupportsGrowingAlphabet;
 import net.automatalib.automaton.fsa.DFA;
 import net.automatalib.automaton.fsa.impl.CompactDFA;
-import net.automatalib.common.smartcollection.ArrayStorage;
+import net.automatalib.common.util.array.ArrayStorage;
 import net.automatalib.word.Word;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/algorithms/active/kearns-vazirani/src/main/java/module-info.java
+++ b/algorithms/active/kearns-vazirani/src/main/java/module-info.java
@@ -34,7 +34,7 @@ open module de.learnlib.algorithm.kv {
     requires de.learnlib.common.util;
     requires de.learnlib.datastructure.discriminationtree;
     requires net.automatalib.api;
-    requires net.automatalib.common.smartcollection;
+    requires net.automatalib.common.util;
     requires net.automatalib.core;
     requires org.checkerframework.checker.qual;
     requires org.slf4j;

--- a/algorithms/active/observation-pack-vpa/pom.xml
+++ b/algorithms/active/observation-pack-vpa/pom.xml
@@ -55,11 +55,6 @@ limitations under the License.
 
         <!-- external -->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.checkerframework</groupId>
             <artifactId>checker-qual</artifactId>
         </dependency>

--- a/algorithms/active/observation-pack-vpa/src/main/java/de/learnlib/algorithm/observationpack/vpa/OPLearnerVPA.java
+++ b/algorithms/active/observation-pack-vpa/src/main/java/de/learnlib/algorithm/observationpack/vpa/OPLearnerVPA.java
@@ -18,7 +18,6 @@ package de.learnlib.algorithm.observationpack.vpa;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.google.common.collect.Iterables;
 import de.learnlib.acex.AbstractBaseCounterexample;
 import de.learnlib.acex.AcexAnalyzer;
 import de.learnlib.algorithm.observationpack.vpa.hypothesis.AbstractHypTrans;
@@ -32,6 +31,7 @@ import net.automatalib.alphabet.VPAlphabet;
 import net.automatalib.automaton.vpa.SEVPA;
 import net.automatalib.automaton.vpa.StackContents;
 import net.automatalib.automaton.vpa.State;
+import net.automatalib.common.util.collection.IterableUtil;
 import net.automatalib.word.Word;
 import net.automatalib.word.WordBuilder;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -134,7 +134,7 @@ public class OPLearnerVPA<I> extends AbstractVPALearner<I> {
         public PrefixTransformAcex(Word<I> word, ContextPair<I> context) {
             super(context.getSuffix().length() + 1);
             this.suffix = context.getSuffix();
-            this.baseState = hypothesis.getState(Iterables.concat(context.getPrefix(), word));
+            this.baseState = hypothesis.getState(IterableUtil.concat(context.getPrefix(), word));
         }
 
         public State<HypLoc<I>> getBaseState() {

--- a/algorithms/active/observation-pack-vpa/src/main/java/de/learnlib/algorithm/observationpack/vpa/hypothesis/HypLoc.java
+++ b/algorithms/active/observation-pack-vpa/src/main/java/de/learnlib/algorithm/observationpack/vpa/hypothesis/HypLoc.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 import de.learnlib.AccessSequenceProvider;
 import net.automatalib.alphabet.VPAlphabet;
-import net.automatalib.common.smartcollection.ArrayStorage;
+import net.automatalib.common.util.array.ArrayStorage;
 import net.automatalib.word.Word;
 
 /**

--- a/algorithms/active/observation-pack-vpa/src/main/java/module-info.java
+++ b/algorithms/active/observation-pack-vpa/src/main/java/module-info.java
@@ -30,7 +30,6 @@
  */
 open module de.learnlib.algorithm.observationpack.vpa {
 
-    requires com.google.common;
     requires de.learnlib.api;
     requires de.learnlib.common.counterexample;
     requires de.learnlib.datastructure.discriminationtree;

--- a/algorithms/active/observation-pack-vpa/src/test/java/de/learnlib/algorithm/observationpack/vpa/DTVisualizationTest.java
+++ b/algorithms/active/observation-pack-vpa/src/test/java/de/learnlib/algorithm/observationpack/vpa/DTVisualizationTest.java
@@ -20,7 +20,6 @@ import java.io.InputStream;
 import java.io.StringWriter;
 import java.util.Random;
 
-import com.google.common.io.CharStreams;
 import de.learnlib.acex.AcexAnalyzers;
 import de.learnlib.oracle.MembershipOracle.DFAMembershipOracle;
 import de.learnlib.oracle.equivalence.vpa.SimulatorEQOracle;
@@ -78,7 +77,7 @@ public class DTVisualizationTest {
     private String resourceAsString(String resourceName) throws IOException {
         try (InputStream is = getClass().getResourceAsStream(resourceName)) {
             assert is != null;
-            return CharStreams.toString(IOUtil.asBufferedUTF8Reader(is));
+            return IOUtil.toString(IOUtil.asBufferedUTF8Reader(is));
         }
     }
 }

--- a/algorithms/active/observation-pack/pom.xml
+++ b/algorithms/active/observation-pack/pom.xml
@@ -59,7 +59,7 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>net.automatalib</groupId>
-            <artifactId>automata-commons-smartcollections</artifactId>
+            <artifactId>automata-commons-util</artifactId>
         </dependency>
 
         <dependency>

--- a/algorithms/active/observation-pack/src/main/java/de/learnlib/algorithm/observationpack/hypothesis/HState.java
+++ b/algorithms/active/observation-pack/src/main/java/de/learnlib/algorithm/observationpack/hypothesis/HState.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import java.util.List;
 
 import de.learnlib.datastructure.discriminationtree.model.AbstractWordBasedDTNode;
-import net.automatalib.common.smartcollection.ResizingArrayStorage;
+import net.automatalib.common.util.array.ResizingArrayStorage;
 import net.automatalib.word.Word;
 import net.automatalib.word.WordBuilder;
 import org.checkerframework.checker.nullness.qual.Nullable;

--- a/algorithms/active/observation-pack/src/main/java/module-info.java
+++ b/algorithms/active/observation-pack/src/main/java/module-info.java
@@ -34,7 +34,7 @@ open module de.learnlib.algorithm.observationpack {
     requires de.learnlib.common.util;
     requires de.learnlib.datastructure.discriminationtree;
     requires net.automatalib.api;
-    requires net.automatalib.common.smartcollection;
+    requires net.automatalib.common.util;
     requires org.checkerframework.checker.qual;
 
     requires static de.learnlib.tooling.annotation;

--- a/algorithms/active/procedural/pom.xml
+++ b/algorithms/active/procedural/pom.xml
@@ -76,11 +76,6 @@ limitations under the License.
 
         <!-- external -->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>net.automatalib</groupId>
             <artifactId>automata-api</artifactId>
         </dependency>

--- a/algorithms/active/procedural/src/main/java/de/learnlib/algorithm/procedural/sba/MappingSBA.java
+++ b/algorithms/active/procedural/src/main/java/de/learnlib/algorithm/procedural/sba/MappingSBA.java
@@ -16,14 +16,15 @@
 package de.learnlib.algorithm.procedural.sba;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import com.google.common.collect.Maps;
 import de.learnlib.algorithm.procedural.SymbolWrapper;
 import net.automatalib.alphabet.ProceduralInputAlphabet;
 import net.automatalib.automaton.fsa.DFA;
 import net.automatalib.automaton.procedural.SBA;
+import net.automatalib.common.util.HashUtil;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 class MappingSBA<S, I> implements SBA<S, I> {
@@ -40,7 +41,7 @@ class MappingSBA<S, I> implements SBA<S, I> {
         this.delegate = delegate;
 
         final Map<SymbolWrapper<I>, DFA<?, SymbolWrapper<I>>> p = delegate.getProcedures();
-        this.procedures = Maps.newHashMapWithExpectedSize(p.size());
+        this.procedures = new HashMap<>(HashUtil.capacity(p.size()));
 
         for (Entry<SymbolWrapper<I>, DFA<?, SymbolWrapper<I>>> e : p.entrySet()) {
             procedures.put(e.getKey().getDelegate(), new DFAView<>(e.getValue()));

--- a/algorithms/active/procedural/src/main/java/de/learnlib/algorithm/procedural/sba/SBALearner.java
+++ b/algorithms/active/procedural/src/main/java/de/learnlib/algorithm/procedural/sba/SBALearner.java
@@ -17,6 +17,7 @@ package de.learnlib.algorithm.procedural.sba;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -24,7 +25,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 
-import com.google.common.collect.Maps;
 import de.learnlib.AccessSequenceTransformer;
 import de.learnlib.acex.AbstractBaseCounterexample;
 import de.learnlib.acex.AcexAnalyzer;
@@ -46,6 +46,7 @@ import net.automatalib.automaton.fsa.DFA;
 import net.automatalib.automaton.procedural.SBA;
 import net.automatalib.automaton.procedural.impl.EmptySBA;
 import net.automatalib.automaton.procedural.impl.StackSBA;
+import net.automatalib.common.util.HashUtil;
 import net.automatalib.common.util.Pair;
 import net.automatalib.common.util.mapping.Mapping;
 import net.automatalib.util.automaton.Automata;
@@ -96,8 +97,8 @@ public class SBALearner<I, L extends DFALearner<SymbolWrapper<I>> & SupportsGrow
         this.analyzer = analyzer;
         this.atManager = atManager;
 
-        this.learners = Maps.newHashMapWithExpectedSize(this.alphabet.getNumCalls());
-        this.mapping = Maps.newHashMapWithExpectedSize(this.alphabet.size());
+        this.learners = new HashMap<>(HashUtil.capacity(this.alphabet.getNumCalls()));
+        this.mapping = new HashMap<>(HashUtil.capacity(this.alphabet.size()));
 
         for (I i : this.alphabet.getInternalAlphabet()) {
             final SymbolWrapper<I> wrapper = new SymbolWrapper<>(i, true);
@@ -172,7 +173,7 @@ public class SBALearner<I, L extends DFALearner<SymbolWrapper<I>> & SupportsGrow
 
         final Map<I, DFA<?, SymbolWrapper<I>>> procedures = getSubModels();
         final Map<SymbolWrapper<I>, DFA<?, SymbolWrapper<I>>> mappedProcedures =
-                Maps.newHashMapWithExpectedSize(procedures.size());
+                new HashMap<>(HashUtil.capacity(procedures.size()));
 
         for (Entry<I, DFA<?, SymbolWrapper<I>>> e : procedures.entrySet()) {
             final SymbolWrapper<I> w = this.mapping.get(e.getKey());
@@ -266,7 +267,7 @@ public class SBALearner<I, L extends DFALearner<SymbolWrapper<I>> & SupportsGrow
     }
 
     private Map<I, DFA<?, SymbolWrapper<I>>> getSubModels() {
-        final Map<I, DFA<?, SymbolWrapper<I>>> subModels = Maps.newHashMapWithExpectedSize(this.learners.size());
+        final Map<I, DFA<?, SymbolWrapper<I>>> subModels = new HashMap<>(HashUtil.capacity(this.learners.size()));
 
         for (Map.Entry<I, L> entry : this.learners.entrySet()) {
             subModels.put(entry.getKey(), entry.getValue().getHypothesisModel());

--- a/algorithms/active/procedural/src/main/java/de/learnlib/algorithm/procedural/sba/manager/DefaultATManager.java
+++ b/algorithms/active/procedural/src/main/java/de/learnlib/algorithm/procedural/sba/manager/DefaultATManager.java
@@ -17,16 +17,17 @@ package de.learnlib.algorithm.procedural.sba.manager;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import de.learnlib.AccessSequenceTransformer;
 import de.learnlib.algorithm.procedural.SymbolWrapper;
 import de.learnlib.algorithm.procedural.sba.ATManager;
 import net.automatalib.alphabet.ProceduralInputAlphabet;
 import net.automatalib.automaton.fsa.DFA;
+import net.automatalib.common.util.HashUtil;
 import net.automatalib.common.util.Pair;
 import net.automatalib.word.Word;
 
@@ -47,8 +48,8 @@ public class DefaultATManager<I> implements ATManager<I> {
     public DefaultATManager(ProceduralInputAlphabet<I> alphabet) {
         this.alphabet = alphabet;
 
-        this.accessSequences = Maps.newHashMapWithExpectedSize(alphabet.getNumCalls());
-        this.terminatingSequences = Maps.newHashMapWithExpectedSize(alphabet.getNumCalls());
+        this.accessSequences = new HashMap<>(HashUtil.capacity(alphabet.getNumCalls()));
+        this.terminatingSequences = new HashMap<>(HashUtil.capacity(alphabet.getNumCalls()));
     }
 
     @Override
@@ -65,8 +66,8 @@ public class DefaultATManager<I> implements ATManager<I> {
 
     @Override
     public Pair<Set<I>, Set<I>> scanPositiveCounterexample(Word<I> input) {
-        final Set<I> newCalls = Sets.newHashSetWithExpectedSize(alphabet.getNumCalls() - accessSequences.size());
-        final Set<I> newTerms = Sets.newHashSetWithExpectedSize(alphabet.getNumCalls() - terminatingSequences.size());
+        final Set<I> newCalls = new HashSet<>(HashUtil.capacity(alphabet.getNumCalls() - accessSequences.size()));
+        final Set<I> newTerms = new HashSet<>(HashUtil.capacity(alphabet.getNumCalls() - terminatingSequences.size()));
 
         for (int i = 0; i < input.size(); i++) {
             final I sym = input.getSymbol(i);

--- a/algorithms/active/procedural/src/main/java/de/learnlib/algorithm/procedural/sba/manager/OptimizingATManager.java
+++ b/algorithms/active/procedural/src/main/java/de/learnlib/algorithm/procedural/sba/manager/OptimizingATManager.java
@@ -17,19 +17,20 @@ package de.learnlib.algorithm.procedural.sba.manager;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import de.learnlib.AccessSequenceTransformer;
 import de.learnlib.algorithm.procedural.SymbolWrapper;
 import de.learnlib.algorithm.procedural.sba.ATManager;
 import net.automatalib.alphabet.ProceduralInputAlphabet;
 import net.automatalib.automaton.fsa.DFA;
+import net.automatalib.common.util.HashUtil;
 import net.automatalib.common.util.Pair;
 import net.automatalib.util.automaton.cover.Covers;
 import net.automatalib.word.Word;
@@ -54,8 +55,8 @@ public class OptimizingATManager<I> implements ATManager<I> {
     public OptimizingATManager(ProceduralInputAlphabet<I> alphabet) {
         this.alphabet = alphabet;
 
-        this.accessSequences = Maps.newHashMapWithExpectedSize(alphabet.getNumCalls());
-        this.terminatingSequences = Maps.newHashMapWithExpectedSize(alphabet.getNumCalls());
+        this.accessSequences = new HashMap<>(HashUtil.capacity(alphabet.getNumCalls()));
+        this.terminatingSequences = new HashMap<>(HashUtil.capacity(alphabet.getNumCalls()));
     }
 
     @Override
@@ -73,9 +74,9 @@ public class OptimizingATManager<I> implements ATManager<I> {
     @Override
     public Pair<Set<I>, Set<I>> scanPositiveCounterexample(Word<I> counterexample) {
         final Set<I> newCalls =
-                Sets.newHashSetWithExpectedSize(this.alphabet.getNumCalls() - this.accessSequences.size());
+                new HashSet<>(HashUtil.capacity(this.alphabet.getNumCalls() - this.accessSequences.size()));
         final Set<I> newTerms =
-                Sets.newHashSetWithExpectedSize(this.alphabet.getNumCalls() - this.terminatingSequences.size());
+                new HashSet<>(HashUtil.capacity(this.alphabet.getNumCalls() - this.terminatingSequences.size()));
 
         this.extractPotentialTerminatingSequences(counterexample, newTerms);
         this.extractPotentialAccessSequences(counterexample, newCalls);
@@ -88,7 +89,7 @@ public class OptimizingATManager<I> implements ATManager<I> {
                                  Map<I, ? extends AccessSequenceTransformer<SymbolWrapper<I>>> providers,
                                  Collection<SymbolWrapper<I>> inputs) {
 
-        final Set<I> newTS = Sets.newHashSetWithExpectedSize(procedures.size());
+        final Set<I> newTS = new HashSet<>(HashUtil.capacity(procedures.size()));
         if (!procedures.isEmpty()) {
 
             final SymbolWrapper<I> returnSymbol = inputs.stream()

--- a/algorithms/active/procedural/src/main/java/de/learnlib/algorithm/procedural/spa/SPALearner.java
+++ b/algorithms/active/procedural/src/main/java/de/learnlib/algorithm/procedural/spa/SPALearner.java
@@ -19,14 +19,14 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import de.learnlib.AccessSequenceTransformer;
 import de.learnlib.acex.AbstractBaseCounterexample;
 import de.learnlib.acex.AcexAnalyzer;
@@ -45,6 +45,7 @@ import net.automatalib.automaton.fsa.DFA;
 import net.automatalib.automaton.procedural.SPA;
 import net.automatalib.automaton.procedural.impl.EmptySPA;
 import net.automatalib.automaton.procedural.impl.StackSPA;
+import net.automatalib.common.util.HashUtil;
 import net.automatalib.common.util.mapping.Mapping;
 import net.automatalib.word.Word;
 import net.automatalib.word.WordBuilder;
@@ -92,8 +93,8 @@ public class SPALearner<I, L extends DFALearner<I> & SupportsGrowingAlphabet<I> 
         this.analyzer = analyzer;
         this.atrManager = atrManager;
 
-        this.subLearners = Maps.newHashMapWithExpectedSize(this.alphabet.getNumCalls());
-        this.activeAlphabet = Sets.newHashSetWithExpectedSize(alphabet.getNumCalls() + alphabet.getNumInternals());
+        this.subLearners = new HashMap<>(HashUtil.capacity(this.alphabet.getNumCalls()));
+        this.activeAlphabet = new HashSet<>(HashUtil.capacity(alphabet.getNumCalls() + alphabet.getNumInternals()));
         this.activeAlphabet.addAll(alphabet.getInternalAlphabet());
     }
 
@@ -214,7 +215,7 @@ public class SPALearner<I, L extends DFALearner<I> & SupportsGrowingAlphabet<I> 
     }
 
     private Map<I, DFA<?, I>> getSubModels() {
-        final Map<I, DFA<?, I>> subModels = Maps.newHashMapWithExpectedSize(this.subLearners.size());
+        final Map<I, DFA<?, I>> subModels = new HashMap<>(HashUtil.capacity(this.subLearners.size()));
 
         for (Map.Entry<I, L> entry : this.subLearners.entrySet()) {
             subModels.put(entry.getKey(), entry.getValue().getHypothesisModel());

--- a/algorithms/active/procedural/src/main/java/de/learnlib/algorithm/procedural/spa/manager/DefaultATRManager.java
+++ b/algorithms/active/procedural/src/main/java/de/learnlib/algorithm/procedural/spa/manager/DefaultATRManager.java
@@ -16,15 +16,16 @@
 package de.learnlib.algorithm.procedural.spa.manager;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import de.learnlib.AccessSequenceTransformer;
 import de.learnlib.algorithm.procedural.spa.ATRManager;
 import net.automatalib.alphabet.ProceduralInputAlphabet;
 import net.automatalib.automaton.fsa.DFA;
+import net.automatalib.common.util.HashUtil;
 import net.automatalib.word.Word;
 
 /**
@@ -45,9 +46,9 @@ public class DefaultATRManager<I> implements ATRManager<I> {
     public DefaultATRManager(ProceduralInputAlphabet<I> alphabet) {
         this.alphabet = alphabet;
 
-        this.accessSequences = Maps.newHashMapWithExpectedSize(alphabet.getNumCalls());
-        this.returnSequences = Maps.newHashMapWithExpectedSize(alphabet.getNumCalls());
-        this.terminatingSequences = Maps.newHashMapWithExpectedSize(alphabet.getNumCalls());
+        this.accessSequences = new HashMap<>(HashUtil.capacity(alphabet.getNumCalls()));
+        this.returnSequences = new HashMap<>(HashUtil.capacity(alphabet.getNumCalls()));
+        this.terminatingSequences = new HashMap<>(HashUtil.capacity(alphabet.getNumCalls()));
     }
 
     @Override
@@ -70,7 +71,7 @@ public class DefaultATRManager<I> implements ATRManager<I> {
 
     @Override
     public Set<I> scanPositiveCounterexample(Word<I> input) {
-        final Set<I> result = Sets.newHashSetWithExpectedSize(alphabet.getNumCalls() - accessSequences.size());
+        final Set<I> result = new HashSet<>(HashUtil.capacity(alphabet.getNumCalls() - accessSequences.size()));
 
         for (int i = 0; i < input.size(); i++) {
             final I sym = input.getSymbol(i);

--- a/algorithms/active/procedural/src/main/java/de/learnlib/algorithm/procedural/spa/manager/OptimizingATRManager.java
+++ b/algorithms/active/procedural/src/main/java/de/learnlib/algorithm/procedural/spa/manager/OptimizingATRManager.java
@@ -23,14 +23,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Spliterators;
-import java.util.stream.StreamSupport;
 
 import de.learnlib.AccessSequenceTransformer;
 import de.learnlib.algorithm.procedural.spa.ATRManager;
 import net.automatalib.alphabet.ProceduralInputAlphabet;
 import net.automatalib.automaton.fsa.DFA;
 import net.automatalib.common.util.HashUtil;
+import net.automatalib.common.util.collection.IteratorUtil;
 import net.automatalib.util.automaton.cover.Covers;
 import net.automatalib.word.Word;
 import net.automatalib.word.WordBuilder;
@@ -125,13 +124,12 @@ public class OptimizingATRManager<I> implements ATRManager<I> {
     private <S> @Nullable Word<I> getShortestHypothesisTS(DFA<S, I> hyp,
                                                           AccessSequenceTransformer<I> asTransformer,
                                                           Collection<I> inputs) {
-        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(Covers.stateCoverIterator(hyp, inputs), 0),
-                                    false)
-                            .filter(hyp::accepts)
-                            .map(asTransformer::transformAccessSequence)
-                            .map(as -> this.alphabet.expand(as, terminatingSequences::get))
-                            .min(Comparator.comparingInt(Word::size))
-                            .orElse(null);
+        return IteratorUtil.stream(Covers.stateCoverIterator(hyp, inputs))
+                           .filter(hyp::accepts)
+                           .map(asTransformer::transformAccessSequence)
+                           .map(as -> this.alphabet.expand(as, terminatingSequences::get))
+                           .min(Comparator.comparingInt(Word::size))
+                           .orElse(null);
     }
 
     private void optimizeSequences(Map<I, Word<I>> sequences) {

--- a/algorithms/active/procedural/src/main/java/de/learnlib/algorithm/procedural/spa/manager/OptimizingATRManager.java
+++ b/algorithms/active/procedural/src/main/java/de/learnlib/algorithm/procedural/spa/manager/OptimizingATRManager.java
@@ -18,17 +18,19 @@ package de.learnlib.algorithm.procedural.spa.manager;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Spliterators;
+import java.util.stream.StreamSupport;
 
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-import com.google.common.collect.Streams;
 import de.learnlib.AccessSequenceTransformer;
 import de.learnlib.algorithm.procedural.spa.ATRManager;
 import net.automatalib.alphabet.ProceduralInputAlphabet;
 import net.automatalib.automaton.fsa.DFA;
+import net.automatalib.common.util.HashUtil;
 import net.automatalib.util.automaton.cover.Covers;
 import net.automatalib.word.Word;
 import net.automatalib.word.WordBuilder;
@@ -52,9 +54,9 @@ public class OptimizingATRManager<I> implements ATRManager<I> {
     public OptimizingATRManager(ProceduralInputAlphabet<I> alphabet) {
         this.alphabet = alphabet;
 
-        this.accessSequences = Maps.newHashMapWithExpectedSize(alphabet.getNumCalls());
-        this.returnSequences = Maps.newHashMapWithExpectedSize(alphabet.getNumCalls());
-        this.terminatingSequences = Maps.newHashMapWithExpectedSize(alphabet.getNumCalls());
+        this.accessSequences = new HashMap<>(HashUtil.capacity(alphabet.getNumCalls()));
+        this.returnSequences = new HashMap<>(HashUtil.capacity(alphabet.getNumCalls()));
+        this.terminatingSequences = new HashMap<>(HashUtil.capacity(alphabet.getNumCalls()));
     }
 
     @Override
@@ -78,7 +80,7 @@ public class OptimizingATRManager<I> implements ATRManager<I> {
     @Override
     public Set<I> scanPositiveCounterexample(Word<I> input) {
         final Set<I> newProcedures =
-                Sets.newHashSetWithExpectedSize(this.alphabet.getNumCalls() - this.terminatingSequences.size());
+                new HashSet<>(HashUtil.capacity(this.alphabet.getNumCalls() - this.terminatingSequences.size()));
 
         this.extractPotentialTerminatingSequences(input, newProcedures);
         this.extractPotentialAccessAndReturnSequences(input);
@@ -123,12 +125,13 @@ public class OptimizingATRManager<I> implements ATRManager<I> {
     private <S> @Nullable Word<I> getShortestHypothesisTS(DFA<S, I> hyp,
                                                           AccessSequenceTransformer<I> asTransformer,
                                                           Collection<I> inputs) {
-        return Streams.stream(Covers.stateCoverIterator(hyp, inputs))
-                      .filter(hyp::accepts)
-                      .map(asTransformer::transformAccessSequence)
-                      .map(as -> this.alphabet.expand(as, terminatingSequences::get))
-                      .min(Comparator.comparingInt(Word::size))
-                      .orElse(null);
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(Covers.stateCoverIterator(hyp, inputs), 0),
+                                    false)
+                            .filter(hyp::accepts)
+                            .map(asTransformer::transformAccessSequence)
+                            .map(as -> this.alphabet.expand(as, terminatingSequences::get))
+                            .min(Comparator.comparingInt(Word::size))
+                            .orElse(null);
     }
 
     private void optimizeSequences(Map<I, Word<I>> sequences) {

--- a/algorithms/active/procedural/src/main/java/de/learnlib/algorithm/procedural/spmm/MappingSPMM.java
+++ b/algorithms/active/procedural/src/main/java/de/learnlib/algorithm/procedural/spmm/MappingSPMM.java
@@ -16,14 +16,15 @@
 package de.learnlib.algorithm.procedural.spmm;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import com.google.common.collect.Maps;
 import de.learnlib.algorithm.procedural.SymbolWrapper;
 import net.automatalib.alphabet.ProceduralInputAlphabet;
 import net.automatalib.automaton.procedural.SPMM;
 import net.automatalib.automaton.transducer.MealyMachine;
+import net.automatalib.common.util.HashUtil;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 class MappingSPMM<S, I, T, O> implements SPMM<S, I, T, O> {
@@ -45,7 +46,7 @@ class MappingSPMM<S, I, T, O> implements SPMM<S, I, T, O> {
         this.delegate = delegate;
 
         final Map<SymbolWrapper<I>, MealyMachine<?, SymbolWrapper<I>, ?, O>> p = delegate.getProcedures();
-        this.procedures = Maps.newHashMapWithExpectedSize(p.size());
+        this.procedures = new HashMap<>(HashUtil.capacity(p.size()));
 
         for (Entry<SymbolWrapper<I>, MealyMachine<?, SymbolWrapper<I>, ?, O>> e : p.entrySet()) {
             procedures.put(e.getKey().getDelegate(), new MealyView<>(e.getValue()));

--- a/algorithms/active/procedural/src/main/java/de/learnlib/algorithm/procedural/spmm/SPMMLearner.java
+++ b/algorithms/active/procedural/src/main/java/de/learnlib/algorithm/procedural/spmm/SPMMLearner.java
@@ -17,6 +17,7 @@ package de.learnlib.algorithm.procedural.spmm;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -24,7 +25,6 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 
-import com.google.common.collect.Maps;
 import de.learnlib.AccessSequenceTransformer;
 import de.learnlib.algorithm.LearnerConstructor;
 import de.learnlib.algorithm.LearningAlgorithm;
@@ -43,6 +43,7 @@ import net.automatalib.automaton.procedural.SPMM;
 import net.automatalib.automaton.procedural.impl.EmptySPMM;
 import net.automatalib.automaton.procedural.impl.StackSPMM;
 import net.automatalib.automaton.transducer.MealyMachine;
+import net.automatalib.common.util.HashUtil;
 import net.automatalib.common.util.Pair;
 import net.automatalib.common.util.mapping.Mapping;
 import net.automatalib.util.automaton.Automata;
@@ -97,8 +98,8 @@ public class SPMMLearner<I, O, L extends MealyLearner<SymbolWrapper<I>, O> & Sup
         this.learnerConstructors = learnerConstructors;
         this.atManager = atManager;
 
-        this.learners = Maps.newHashMapWithExpectedSize(this.alphabet.getNumCalls());
-        this.mapping = Maps.newHashMapWithExpectedSize(this.alphabet.size());
+        this.learners = new HashMap<>(HashUtil.capacity(this.alphabet.getNumCalls()));
+        this.mapping = new HashMap<>(HashUtil.capacity(this.alphabet.size()));
 
         for (I i : this.alphabet.getInternalAlphabet()) {
             final SymbolWrapper<I> wrapper = new SymbolWrapper<>(i, true);
@@ -173,7 +174,7 @@ public class SPMMLearner<I, O, L extends MealyLearner<SymbolWrapper<I>, O> & Sup
 
         final Map<I, MealyMachine<?, SymbolWrapper<I>, ?, O>> procedures = getSubModels();
         final Map<SymbolWrapper<I>, MealyMachine<?, SymbolWrapper<I>, ?, O>> mappedProcedures =
-                Maps.newHashMapWithExpectedSize(procedures.size());
+                new HashMap<>(HashUtil.capacity(procedures.size()));
 
         for (Entry<I, MealyMachine<?, SymbolWrapper<I>, ?, O>> e : procedures.entrySet()) {
             final SymbolWrapper<I> w = this.mapping.get(e.getKey());
@@ -271,7 +272,7 @@ public class SPMMLearner<I, O, L extends MealyLearner<SymbolWrapper<I>, O> & Sup
 
     private Map<I, MealyMachine<?, SymbolWrapper<I>, ?, O>> getSubModels() {
         final Map<I, MealyMachine<?, SymbolWrapper<I>, ?, O>> subModels =
-                Maps.newHashMapWithExpectedSize(this.learners.size());
+                new HashMap<>(HashUtil.capacity(this.learners.size()));
 
         for (Map.Entry<I, L> entry : this.learners.entrySet()) {
             subModels.put(entry.getKey(), entry.getValue().getHypothesisModel());

--- a/algorithms/active/procedural/src/main/java/de/learnlib/algorithm/procedural/spmm/manager/DefaultATManager.java
+++ b/algorithms/active/procedural/src/main/java/de/learnlib/algorithm/procedural/spmm/manager/DefaultATManager.java
@@ -17,18 +17,19 @@ package de.learnlib.algorithm.procedural.spmm.manager;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import de.learnlib.AccessSequenceTransformer;
 import de.learnlib.algorithm.procedural.SymbolWrapper;
 import de.learnlib.algorithm.procedural.spmm.ATManager;
 import de.learnlib.query.DefaultQuery;
 import net.automatalib.alphabet.ProceduralInputAlphabet;
 import net.automatalib.automaton.transducer.MealyMachine;
+import net.automatalib.common.util.HashUtil;
 import net.automatalib.common.util.Pair;
 import net.automatalib.word.Word;
 
@@ -53,8 +54,8 @@ public class DefaultATManager<I, O> implements ATManager<I, O> {
         this.inputAlphabet = inputAlphabet;
         this.errorOutput = errorOutput;
 
-        this.accessSequences = Maps.newHashMapWithExpectedSize(inputAlphabet.getNumCalls());
-        this.terminatingSequences = Maps.newHashMapWithExpectedSize(inputAlphabet.getNumCalls());
+        this.accessSequences = new HashMap<>(HashUtil.capacity(inputAlphabet.getNumCalls()));
+        this.terminatingSequences = new HashMap<>(HashUtil.capacity(inputAlphabet.getNumCalls()));
     }
 
     @Override
@@ -71,9 +72,9 @@ public class DefaultATManager<I, O> implements ATManager<I, O> {
 
     @Override
     public Pair<Set<I>, Set<I>> scanCounterexample(DefaultQuery<I, Word<O>> counterexample) {
-        final Set<I> newCalls = Sets.newHashSetWithExpectedSize(inputAlphabet.getNumCalls() - accessSequences.size());
+        final Set<I> newCalls = new HashSet<>(HashUtil.capacity(inputAlphabet.getNumCalls() - accessSequences.size()));
         final Set<I> newTerms =
-                Sets.newHashSetWithExpectedSize(inputAlphabet.getNumCalls() - terminatingSequences.size());
+                new HashSet<>(HashUtil.capacity(inputAlphabet.getNumCalls() - terminatingSequences.size()));
 
         final Word<I> input = counterexample.getInput();
         final Word<O> output = counterexample.getOutput();

--- a/algorithms/active/procedural/src/main/java/de/learnlib/algorithm/procedural/spmm/manager/OptimizingATManager.java
+++ b/algorithms/active/procedural/src/main/java/de/learnlib/algorithm/procedural/spmm/manager/OptimizingATManager.java
@@ -17,6 +17,8 @@ package de.learnlib.algorithm.procedural.spmm.manager;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -24,14 +26,13 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import de.learnlib.AccessSequenceTransformer;
 import de.learnlib.algorithm.procedural.SymbolWrapper;
 import de.learnlib.algorithm.procedural.spmm.ATManager;
 import de.learnlib.query.DefaultQuery;
 import net.automatalib.alphabet.ProceduralInputAlphabet;
 import net.automatalib.automaton.transducer.MealyMachine;
+import net.automatalib.common.util.HashUtil;
 import net.automatalib.common.util.Pair;
 import net.automatalib.util.automaton.cover.Covers;
 import net.automatalib.word.Word;
@@ -59,8 +60,8 @@ public class OptimizingATManager<I, O> implements ATManager<I, O> {
         this.inputAlphabet = inputAlphabet;
         this.errorOutput = errorOutput;
 
-        this.accessSequences = Maps.newHashMapWithExpectedSize(inputAlphabet.getNumCalls());
-        this.terminatingSequences = Maps.newHashMapWithExpectedSize(inputAlphabet.getNumCalls());
+        this.accessSequences = new HashMap<>(HashUtil.capacity(inputAlphabet.getNumCalls()));
+        this.terminatingSequences = new HashMap<>(HashUtil.capacity(inputAlphabet.getNumCalls()));
     }
 
     @Override
@@ -78,9 +79,9 @@ public class OptimizingATManager<I, O> implements ATManager<I, O> {
     @Override
     public Pair<Set<I>, Set<I>> scanCounterexample(DefaultQuery<I, Word<O>> counterexample) {
         final Set<I> newCalls =
-                Sets.newHashSetWithExpectedSize(this.inputAlphabet.getNumCalls() - this.accessSequences.size());
+                new HashSet<>(HashUtil.capacity(this.inputAlphabet.getNumCalls() - this.accessSequences.size()));
         final Set<I> newTerms =
-                Sets.newHashSetWithExpectedSize(this.inputAlphabet.getNumCalls() - this.terminatingSequences.size());
+                new HashSet<>(HashUtil.capacity(this.inputAlphabet.getNumCalls() - this.terminatingSequences.size()));
 
         this.extractPotentialTerminatingSequences(counterexample, newTerms);
         this.extractPotentialAccessSequences(counterexample, newCalls);
@@ -93,7 +94,7 @@ public class OptimizingATManager<I, O> implements ATManager<I, O> {
                                  Map<I, ? extends AccessSequenceTransformer<SymbolWrapper<I>>> providers,
                                  Collection<SymbolWrapper<I>> inputs) {
 
-        final Set<I> newTS = Sets.newHashSetWithExpectedSize(procedures.size());
+        final Set<I> newTS = new HashSet<>(HashUtil.capacity(procedures.size()));
         if (!procedures.isEmpty()) {
 
             final SymbolWrapper<I> returnSymbol = inputs.stream()

--- a/algorithms/active/procedural/src/main/java/module-info.java
+++ b/algorithms/active/procedural/src/main/java/module-info.java
@@ -31,7 +31,6 @@
  */
 open module de.learnlib.algorithm.procedural {
 
-    requires com.google.common;
     requires de.learnlib.algorithm.kv;
     requires de.learnlib.algorithm.lstar;
     requires de.learnlib.algorithm.observationpack;

--- a/algorithms/active/ttt-vpa/pom.xml
+++ b/algorithms/active/ttt-vpa/pom.xml
@@ -62,6 +62,10 @@ limitations under the License.
             <groupId>net.automatalib</groupId>
             <artifactId>automata-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>net.automatalib</groupId>
+            <artifactId>automata-commons-util</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.checkerframework</groupId>

--- a/algorithms/active/ttt-vpa/pom.xml
+++ b/algorithms/active/ttt-vpa/pom.xml
@@ -59,11 +59,6 @@ limitations under the License.
 
         <!-- external -->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>net.automatalib</groupId>
             <artifactId>automata-api</artifactId>
         </dependency>

--- a/algorithms/active/ttt-vpa/src/main/java/de/learnlib/algorithm/ttt/vpa/TTTLearnerVPA.java
+++ b/algorithms/active/ttt-vpa/src/main/java/de/learnlib/algorithm/ttt/vpa/TTTLearnerVPA.java
@@ -42,6 +42,7 @@ import net.automatalib.alphabet.VPAlphabet;
 import net.automatalib.automaton.vpa.SEVPA;
 import net.automatalib.automaton.vpa.StackContents;
 import net.automatalib.automaton.vpa.State;
+import net.automatalib.common.util.collection.CollectionUtil;
 import net.automatalib.word.Word;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -83,7 +84,7 @@ public class TTTLearnerVPA<I> extends OPLearnerVPA<I> {
                         if (trans.isTree()) {
                             succs.add(trans.getTreeTarget());
                         } else {
-                            trans.getNonTreeTarget().subtreeLocations().forEach(succs::add);
+                            CollectionUtil.add(succs, trans.getNonTreeTarget().subtreeLocsIterator());
                         }
                     }
                 }
@@ -95,7 +96,7 @@ public class TTTLearnerVPA<I> extends OPLearnerVPA<I> {
                     if (trans.isTree()) {
                         succs.add(trans.getTreeTarget());
                     } else {
-                        trans.getNonTreeTarget().subtreeLocations().forEach(succs::add);
+                        CollectionUtil.add(succs, trans.getNonTreeTarget().subtreeLocsIterator());
                     }
                 }
                 curr = new NonDetState<>(succs, curr.getStack());

--- a/algorithms/active/ttt-vpa/src/main/java/de/learnlib/algorithm/ttt/vpa/TTTLearnerVPA.java
+++ b/algorithms/active/ttt-vpa/src/main/java/de/learnlib/algorithm/ttt/vpa/TTTLearnerVPA.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import com.google.common.collect.Iterables;
 import de.learnlib.acex.AcexAnalyzer;
 import de.learnlib.algorithm.observationpack.vpa.OPLearnerVPA;
 import de.learnlib.algorithm.observationpack.vpa.hypothesis.AbstractHypTrans;
@@ -84,7 +83,7 @@ public class TTTLearnerVPA<I> extends OPLearnerVPA<I> {
                         if (trans.isTree()) {
                             succs.add(trans.getTreeTarget());
                         } else {
-                            Iterables.addAll(succs, trans.getNonTreeTarget().subtreeLocations());
+                            trans.getNonTreeTarget().subtreeLocations().forEach(succs::add);
                         }
                     }
                 }
@@ -96,7 +95,7 @@ public class TTTLearnerVPA<I> extends OPLearnerVPA<I> {
                     if (trans.isTree()) {
                         succs.add(trans.getTreeTarget());
                     } else {
-                        Iterables.addAll(succs, trans.getNonTreeTarget().subtreeLocations());
+                        trans.getNonTreeTarget().subtreeLocations().forEach(succs::add);
                     }
                 }
                 curr = new NonDetState<>(succs, curr.getStack());

--- a/algorithms/active/ttt-vpa/src/main/java/module-info.java
+++ b/algorithms/active/ttt-vpa/src/main/java/module-info.java
@@ -30,7 +30,6 @@
  */
 open module de.learnlib.algorithm.ttt.vpa {
 
-    requires com.google.common;
     requires de.learnlib.api;
     requires de.learnlib.algorithm.observationpack.vpa;
     requires de.learnlib.common.counterexample;

--- a/algorithms/active/ttt-vpa/src/main/java/module-info.java
+++ b/algorithms/active/ttt-vpa/src/main/java/module-info.java
@@ -38,6 +38,7 @@ open module de.learnlib.algorithm.ttt.vpa {
     requires org.checkerframework.checker.qual;
 
     requires static de.learnlib.tooling.annotation;
+    requires net.automatalib.common.util;
 
     exports de.learnlib.algorithm.ttt.vpa;
 }

--- a/algorithms/active/ttt/pom.xml
+++ b/algorithms/active/ttt/pom.xml
@@ -59,17 +59,16 @@ limitations under the License.
 
         <!-- external -->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>net.automatalib</groupId>
             <artifactId>automata-api</artifactId>
         </dependency>
         <dependency>
             <groupId>net.automatalib</groupId>
             <artifactId>automata-commons-smartcollections</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.automatalib</groupId>
+            <artifactId>automata-commons-util</artifactId>
         </dependency>
 
         <dependency>

--- a/algorithms/active/ttt/src/main/java/de/learnlib/algorithm/ttt/base/AbstractTTTLearner.java
+++ b/algorithms/active/ttt/src/main/java/de/learnlib/algorithm/ttt/base/AbstractTTTLearner.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import com.google.common.collect.Iterators;
 import de.learnlib.AccessSequenceProvider;
 import de.learnlib.Resumable;
 import de.learnlib.acex.AcexAnalyzer;
@@ -43,6 +42,7 @@ import net.automatalib.alphabet.Alphabet;
 import net.automatalib.alphabet.SupportsGrowingAlphabet;
 import net.automatalib.common.smartcollection.ElementReference;
 import net.automatalib.common.smartcollection.UnorderedCollection;
+import net.automatalib.common.util.collection.CollectionsUtil;
 import net.automatalib.word.Word;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
@@ -344,7 +344,7 @@ public abstract class AbstractTTTLearner<A, I, D>
                 result.add(trans.getTreeTarget());
             } else {
                 AbstractBaseDTNode<I, D> tgtNode = trans.getNonTreeTarget();
-                Iterators.addAll(result, tgtNode.subtreeStatesIterator());
+                CollectionsUtil.add(result, tgtNode.subtreeStatesIterator());
             }
         }
         return result;

--- a/algorithms/active/ttt/src/main/java/de/learnlib/algorithm/ttt/base/AbstractTTTLearner.java
+++ b/algorithms/active/ttt/src/main/java/de/learnlib/algorithm/ttt/base/AbstractTTTLearner.java
@@ -42,7 +42,7 @@ import net.automatalib.alphabet.Alphabet;
 import net.automatalib.alphabet.SupportsGrowingAlphabet;
 import net.automatalib.common.smartcollection.ElementReference;
 import net.automatalib.common.smartcollection.UnorderedCollection;
-import net.automatalib.common.util.collection.CollectionsUtil;
+import net.automatalib.common.util.collection.CollectionUtil;
 import net.automatalib.word.Word;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
@@ -344,7 +344,7 @@ public abstract class AbstractTTTLearner<A, I, D>
                 result.add(trans.getTreeTarget());
             } else {
                 AbstractBaseDTNode<I, D> tgtNode = trans.getNonTreeTarget();
-                CollectionsUtil.add(result, tgtNode.subtreeStatesIterator());
+                CollectionUtil.add(result, tgtNode.subtreeStatesIterator());
             }
         }
         return result;

--- a/algorithms/active/ttt/src/main/java/de/learnlib/algorithm/ttt/base/TTTState.java
+++ b/algorithms/active/ttt/src/main/java/de/learnlib/algorithm/ttt/base/TTTState.java
@@ -16,7 +16,7 @@
 package de.learnlib.algorithm.ttt.base;
 
 import de.learnlib.AccessSequenceProvider;
-import net.automatalib.common.smartcollection.ResizingArrayStorage;
+import net.automatalib.common.util.array.ResizingArrayStorage;
 import net.automatalib.word.Word;
 
 /**

--- a/algorithms/active/ttt/src/main/java/de/learnlib/algorithm/ttt/dfa/PrefixTTTLearnerDFA.java
+++ b/algorithms/active/ttt/src/main/java/de/learnlib/algorithm/ttt/dfa/PrefixTTTLearnerDFA.java
@@ -17,7 +17,6 @@ package de.learnlib.algorithm.ttt.dfa;
 
 import java.util.Iterator;
 
-import com.google.common.collect.AbstractIterator;
 import de.learnlib.acex.AbstractCounterexample;
 import de.learnlib.acex.AcexAnalyzer;
 import de.learnlib.algorithm.ttt.base.TTTState;
@@ -25,7 +24,8 @@ import de.learnlib.algorithm.ttt.base.TTTTransition;
 import de.learnlib.oracle.MembershipOracle;
 import de.learnlib.query.DefaultQuery;
 import net.automatalib.alphabet.Alphabet;
-import net.automatalib.common.smartcollection.ArrayStorage;
+import net.automatalib.common.util.array.ArrayStorage;
+import net.automatalib.common.util.collection.AbstractSimplifiedIterator;
 import net.automatalib.word.Word;
 
 public class PrefixTTTLearnerDFA<I> extends TTTLearnerDFA<I> {
@@ -150,7 +150,7 @@ public class PrefixTTTLearnerDFA<I> extends TTTLearnerDFA<I> {
             return new UnlabeledIterator<>(this);
         }
 
-        private static class UnlabeledIterator<I> extends AbstractIterator<ExtDTNode<I>> {
+        private static class UnlabeledIterator<I> extends AbstractSimplifiedIterator<ExtDTNode<I>> {
 
             private ExtDTNode<I> curr;
 
@@ -159,12 +159,13 @@ public class PrefixTTTLearnerDFA<I> extends TTTLearnerDFA<I> {
             }
 
             @Override
-            protected ExtDTNode<I> computeNext() {
+            protected boolean calculateNext() {
                 curr = curr.nextUnlabeled;
                 if (curr == null) {
-                    return endOfData();
+                    return false;
                 }
-                return curr;
+                super.nextValue = curr;
+                return true;
             }
         }
     }

--- a/algorithms/active/ttt/src/main/java/module-info.java
+++ b/algorithms/active/ttt/src/main/java/module-info.java
@@ -30,7 +30,6 @@
  */
 open module de.learnlib.algorithm.ttt {
 
-    requires com.google.common;
     requires de.learnlib.api;
     requires de.learnlib.common.counterexample;
     requires de.learnlib.common.util;
@@ -38,6 +37,7 @@ open module de.learnlib.algorithm.ttt {
     requires de.learnlib.datastructure.list;
     requires net.automatalib.api;
     requires net.automatalib.common.smartcollection;
+    requires net.automatalib.common.util;
     requires org.checkerframework.checker.qual;
     requires org.slf4j;
 

--- a/algorithms/passive/ostia/pom.xml
+++ b/algorithms/passive/ostia/pom.xml
@@ -63,12 +63,6 @@ limitations under the License.
 
         <!-- test -->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>de.learnlib.testsupport</groupId>
             <artifactId>learnlib-learner-it-support</artifactId>
         </dependency>

--- a/algorithms/passive/ostia/src/test/java/de/learnlib/algorithm/ostia/OSTIATest.java
+++ b/algorithms/passive/ostia/src/test/java/de/learnlib/algorithm/ostia/OSTIATest.java
@@ -26,8 +26,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 
-import com.google.common.collect.Iterables;
-import com.google.common.io.CharStreams;
 import net.automatalib.alphabet.Alphabet;
 import net.automatalib.alphabet.impl.Alphabets;
 import net.automatalib.automaton.transducer.SubsequentialTransducer;
@@ -104,11 +102,11 @@ public class OSTIATest {
 
         final WordBuilder<Integer> wb = new WordBuilder<>();
         for (Pair<IntSeq, IntSeq> p : getExampleSamples()) {
-            Iterables.addAll(wb, p.getFirst());
+            CollectionsUtil.add(wb, p.getFirst());
             final Word<Integer> input = wb.toWord();
             wb.clear();
 
-            Iterables.addAll(wb, p.getSecond());
+            CollectionsUtil.add(wb, p.getSecond());
             final Word<Integer> output = wb.toWord();
             wb.clear();
 
@@ -120,7 +118,7 @@ public class OSTIATest {
 
         try (InputStream is = getClass().getResourceAsStream("/hyp.dot")) {
             assert is != null;
-            expectedHyp = CharStreams.toString(IOUtil.asBufferedUTF8Reader(is));
+            expectedHyp = IOUtil.toString(IOUtil.asBufferedUTF8Reader(is));
         }
 
         final StringWriter actualHyp = new StringWriter();

--- a/algorithms/passive/ostia/src/test/java/de/learnlib/algorithm/ostia/OSTIATest.java
+++ b/algorithms/passive/ostia/src/test/java/de/learnlib/algorithm/ostia/OSTIATest.java
@@ -33,7 +33,8 @@ import net.automatalib.automaton.transducer.impl.CompactSST;
 import net.automatalib.common.smartcollection.IntSeq;
 import net.automatalib.common.util.IOUtil;
 import net.automatalib.common.util.Pair;
-import net.automatalib.common.util.collection.CollectionsUtil;
+import net.automatalib.common.util.collection.CollectionUtil;
+import net.automatalib.common.util.collection.IterableUtil;
 import net.automatalib.serialization.dot.GraphDOT;
 import net.automatalib.util.automaton.Automata;
 import net.automatalib.util.automaton.conformance.WMethodTestsIterator;
@@ -102,11 +103,11 @@ public class OSTIATest {
 
         final WordBuilder<Integer> wb = new WordBuilder<>();
         for (Pair<IntSeq, IntSeq> p : getExampleSamples()) {
-            CollectionsUtil.add(wb, p.getFirst());
+            CollectionUtil.add(wb, p.getFirst().iterator());
             final Word<Integer> input = wb.toWord();
             wb.clear();
 
-            CollectionsUtil.add(wb, p.getSecond());
+            CollectionUtil.add(wb, p.getSecond().iterator());
             final Word<Integer> output = wb.toWord();
             wb.clear();
 
@@ -134,7 +135,7 @@ public class OSTIATest {
         final CompactSST<Character, String> sst = new CompactSST<>(INPUTS);
 
         final List<Word<String>> words = new ArrayList<>();
-        for (List<String> t : CollectionsUtil.allTuples(OUTPUTS, 0, 3)) {
+        for (List<String> t : IterableUtil.allTuples(OUTPUTS, 0, 3)) {
             words.add(Word.fromList(t));
         }
 

--- a/algorithms/passive/rpni/pom.xml
+++ b/algorithms/passive/rpni/pom.xml
@@ -51,11 +51,6 @@ limitations under the License.
 
         <!-- external -->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>net.automatalib</groupId>
             <artifactId>automata-api</artifactId>
         </dependency>

--- a/algorithms/passive/rpni/src/main/java/de/learnlib/algorithm/rpni/EDSMUtil.java
+++ b/algorithms/passive/rpni/src/main/java/de/learnlib/algorithm/rpni/EDSMUtil.java
@@ -16,12 +16,13 @@
 package de.learnlib.algorithm.rpni;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.collect.Maps;
 import net.automatalib.automaton.UniversalDeterministicAutomaton;
 import net.automatalib.common.smartcollection.IntSeq;
+import net.automatalib.common.util.HashUtil;
 
 final class EDSMUtil {
 
@@ -34,7 +35,7 @@ final class EDSMUtil {
         final Collection<S> states = merge.getStates();
         final int numStates = states.size();
         // we don't use the regular stateIDs because we only want to collect all states once.
-        final Map<S, Integer> stateIDs = Maps.newHashMapWithExpectedSize(numStates);
+        final Map<S, Integer> stateIDs = new HashMap<>(HashUtil.capacity(numStates));
 
         int counter = 0;
         for (S s : states) {

--- a/algorithms/passive/rpni/src/main/java/module-info.java
+++ b/algorithms/passive/rpni/src/main/java/module-info.java
@@ -34,7 +34,6 @@
  */
 open module de.learnlib.algorithm.rpni {
 
-    requires com.google.common;
     requires de.learnlib.api;
     requires de.learnlib.datastructure.pta;
     requires net.automatalib.api;

--- a/commons/counterexamples/pom.xml
+++ b/commons/counterexamples/pom.xml
@@ -44,7 +44,7 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>net.automatalib</groupId>
-            <artifactId>automata-commons-smartcollections</artifactId>
+            <artifactId>automata-commons-util</artifactId>
         </dependency>
 
         <dependency>

--- a/commons/counterexamples/src/main/java/de/learnlib/acex/AbstractBaseCounterexample.java
+++ b/commons/counterexamples/src/main/java/de/learnlib/acex/AbstractBaseCounterexample.java
@@ -15,7 +15,7 @@
  */
 package de.learnlib.acex;
 
-import net.automatalib.common.smartcollection.ArrayStorage;
+import net.automatalib.common.util.array.ArrayStorage;
 import org.checkerframework.checker.initialization.qual.UnknownInitialization;
 
 public abstract class AbstractBaseCounterexample<E> implements AbstractCounterexample<E> {

--- a/commons/counterexamples/src/main/java/module-info.java
+++ b/commons/counterexamples/src/main/java/module-info.java
@@ -30,7 +30,7 @@ open module de.learnlib.common.counterexample {
 
     requires de.learnlib.api;
     requires net.automatalib.api;
-    requires net.automatalib.common.smartcollection;
+    requires net.automatalib.common.util;
     requires org.checkerframework.checker.qual;
 
     exports de.learnlib.acex;

--- a/datastructures/discrimination-tree/pom.xml
+++ b/datastructures/discrimination-tree/pom.xml
@@ -43,17 +43,8 @@ limitations under the License.
 
         <!-- external -->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>net.automatalib</groupId>
             <artifactId>automata-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>net.automatalib</groupId>
-            <artifactId>automata-commons-smartcollections</artifactId>
         </dependency>
         <dependency>
             <groupId>net.automatalib</groupId>

--- a/datastructures/discrimination-tree/src/main/java/de/learnlib/datastructure/discriminationtree/iterators/DiscriminationTreeIterators.java
+++ b/datastructures/discrimination-tree/src/main/java/de/learnlib/datastructure/discriminationtree/iterators/DiscriminationTreeIterators.java
@@ -18,8 +18,8 @@ package de.learnlib.datastructure.discriminationtree.iterators;
 import java.util.Iterator;
 import java.util.function.Function;
 
-import com.google.common.collect.Iterators;
 import de.learnlib.datastructure.discriminationtree.model.AbstractDTNode;
+import net.automatalib.common.util.collection.IteratorUtil;
 
 /**
  * Factory methods for several kinds of discrimination tree node iterators.
@@ -52,7 +52,7 @@ public final class DiscriminationTreeIterators {
      */
     @SuppressWarnings("nullness") // lambda is only called with our non-null nodes as argument
     public static <N extends AbstractDTNode<?, ?, ?, N>> Iterator<N> innerNodeIterator(N root) {
-        return Iterators.filter(nodeIterator(root), n -> !n.isLeaf());
+        return IteratorUtil.filter(nodeIterator(root), n -> !n.isLeaf());
     }
 
     /**
@@ -64,7 +64,7 @@ public final class DiscriminationTreeIterators {
      *         node type
      */
     public static <N extends AbstractDTNode<?, ?, ?, N>> Iterator<N> leafIterator(N root) {
-        return Iterators.filter(nodeIterator(root), AbstractDTNode::isLeaf);
+        return IteratorUtil.filter(nodeIterator(root), AbstractDTNode::isLeaf);
     }
 
     /**
@@ -80,6 +80,6 @@ public final class DiscriminationTreeIterators {
      */
     public static <N extends AbstractDTNode<?, ?, ?, N>, D> Iterator<D> transformingLeafIterator(N root,
                                                                                                  Function<? super N, D> transformer) {
-        return Iterators.transform(leafIterator(root), transformer::apply);
+        return IteratorUtil.map(leafIterator(root), transformer::apply);
     }
 }

--- a/datastructures/discrimination-tree/src/main/java/de/learnlib/datastructure/discriminationtree/iterators/DiscriminationTreeIterators.java
+++ b/datastructures/discrimination-tree/src/main/java/de/learnlib/datastructure/discriminationtree/iterators/DiscriminationTreeIterators.java
@@ -80,6 +80,6 @@ public final class DiscriminationTreeIterators {
      */
     public static <N extends AbstractDTNode<?, ?, ?, N>, D> Iterator<D> transformingLeafIterator(N root,
                                                                                                  Function<? super N, D> transformer) {
-        return IteratorUtil.map(leafIterator(root), transformer::apply);
+        return IteratorUtil.map(leafIterator(root), transformer);
     }
 }

--- a/datastructures/discrimination-tree/src/main/java/de/learnlib/datastructure/discriminationtree/iterators/NodeIterator.java
+++ b/datastructures/discrimination-tree/src/main/java/de/learnlib/datastructure/discriminationtree/iterators/NodeIterator.java
@@ -17,8 +17,9 @@ package de.learnlib.datastructure.discriminationtree.iterators;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
 
-import com.google.common.collect.AbstractIterator;
 import de.learnlib.datastructure.discriminationtree.model.AbstractDTNode;
 
 /**
@@ -27,7 +28,7 @@ import de.learnlib.datastructure.discriminationtree.model.AbstractDTNode;
  * @param <N>
  *         node type
  */
-class NodeIterator<N extends AbstractDTNode<?, ?, ?, N>> extends AbstractIterator<N> {
+class NodeIterator<N extends AbstractDTNode<?, ?, ?, N>> implements Iterator<N> {
 
     private final Deque<N> stack = new ArrayDeque<>();
 
@@ -36,18 +37,24 @@ class NodeIterator<N extends AbstractDTNode<?, ?, ?, N>> extends AbstractIterato
     }
 
     @Override
-    protected N computeNext() {
-        if (!stack.isEmpty()) {
-            N curr = stack.pop();
+    public boolean hasNext() {
+        return !stack.isEmpty();
+    }
 
-            if (!curr.isLeaf()) {
-                for (N child : curr.getChildren()) {
-                    stack.push(child);
-                }
-            }
-
-            return curr;
+    @Override
+    public N next() {
+        if (stack.isEmpty()) {
+            throw new NoSuchElementException();
         }
-        return endOfData();
+
+        final N curr = stack.pop();
+
+        if (!curr.isLeaf()) {
+            for (N child : curr.getChildren()) {
+                stack.push(child);
+            }
+        }
+
+        return curr;
     }
 }

--- a/datastructures/discrimination-tree/src/main/java/de/learnlib/datastructure/discriminationtree/model/AbstractDiscriminationTree.java
+++ b/datastructures/discrimination-tree/src/main/java/de/learnlib/datastructure/discriminationtree/model/AbstractDiscriminationTree.java
@@ -26,11 +26,11 @@ import java.util.Map.Entry;
 import java.util.RandomAccess;
 import java.util.function.Predicate;
 
-import com.google.common.collect.Iterables;
 import de.learnlib.oracle.MembershipOracle;
 import de.learnlib.query.DefaultQuery;
-import net.automatalib.common.smartcollection.ArrayStorage;
+import net.automatalib.common.util.array.ArrayStorage;
 import net.automatalib.common.util.collection.BitSetIterator;
+import net.automatalib.common.util.collection.IteratorUtil;
 import net.automatalib.graph.Graph;
 import net.automatalib.util.graph.traversal.GraphTraversal;
 import net.automatalib.visualization.DefaultVisualizationHelper;
@@ -233,9 +233,7 @@ public abstract class AbstractDiscriminationTree<DSCR, I, O, D, N extends Abstra
      */
     @Override
     public Collection<N> getNodes() {
-        List<N> nodes = new ArrayList<>();
-        Iterables.addAll(nodes, GraphTraversal.breadthFirstOrder(this, Collections.singleton(root)));
-        return nodes;
+        return IteratorUtil.list(GraphTraversal.breadthFirstIterator(this, Collections.singleton(root)));
     }
 
     @Override

--- a/datastructures/discrimination-tree/src/main/java/module-info.java
+++ b/datastructures/discrimination-tree/src/main/java/module-info.java
@@ -28,11 +28,9 @@
  */
 open module de.learnlib.datastructure.discriminationtree {
 
-    requires com.google.common;
     requires de.learnlib.api;
     requires de.learnlib.datastructure.list;
     requires net.automatalib.api;
-    requires net.automatalib.common.smartcollection;
     requires net.automatalib.common.util;
     requires net.automatalib.util;
     requires org.checkerframework.checker.qual;

--- a/datastructures/discrimination-tree/src/test/java/de/learnlib/datastructure/discriminationtree/IteratorsTest.java
+++ b/datastructures/discrimination-tree/src/test/java/de/learnlib/datastructure/discriminationtree/IteratorsTest.java
@@ -15,13 +15,11 @@
  */
 package de.learnlib.datastructure.discriminationtree;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 
-import com.google.common.collect.Sets;
 import de.learnlib.datastructure.discriminationtree.iterators.DiscriminationTreeIterators;
 import de.learnlib.datastructure.discriminationtree.model.AbstractWordBasedDTNode;
+import net.automatalib.common.util.collection.IteratorUtil;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -30,38 +28,34 @@ public class IteratorsTest {
     @Test
     public void testNodeIterator() {
         final Set<AbstractWordBasedDTNode<Integer, Boolean, Character>> nodes =
-                Sets.newHashSet(DiscriminationTreeIterators.nodeIterator(DummyDT.DT.getRoot()));
+                IteratorUtil.set(DiscriminationTreeIterators.nodeIterator(DummyDT.DT.getRoot()));
 
         Assert.assertEquals(nodes,
-                            new HashSet<>(Arrays.asList(DummyDT.INNER_1,
-                                                        DummyDT.INNER_2,
-                                                        DummyDT.LEAF_1,
-                                                        DummyDT.LEAF_2,
-                                                        DummyDT.LEAF_3)));
+                            Set.of(DummyDT.INNER_1, DummyDT.INNER_2, DummyDT.LEAF_1, DummyDT.LEAF_2, DummyDT.LEAF_3));
     }
 
     @Test
     public void testLeafIterator() {
         final Set<AbstractWordBasedDTNode<Integer, Boolean, Character>> nodes =
-                Sets.newHashSet(DiscriminationTreeIterators.leafIterator(DummyDT.DT.getRoot()));
+                IteratorUtil.set(DiscriminationTreeIterators.leafIterator(DummyDT.DT.getRoot()));
 
-        Assert.assertEquals(nodes, new HashSet<>(Arrays.asList(DummyDT.LEAF_1, DummyDT.LEAF_2, DummyDT.LEAF_3)));
+        Assert.assertEquals(nodes, Set.of(DummyDT.LEAF_1, DummyDT.LEAF_2, DummyDT.LEAF_3));
     }
 
     @Test
     public void testInnerNodeIterator() {
         final Set<AbstractWordBasedDTNode<Integer, Boolean, Character>> nodes =
-                Sets.newHashSet(DiscriminationTreeIterators.innerNodeIterator(DummyDT.DT.getRoot()));
+                IteratorUtil.set(DiscriminationTreeIterators.innerNodeIterator(DummyDT.DT.getRoot()));
 
-        Assert.assertEquals(nodes, new HashSet<>(Arrays.asList(DummyDT.INNER_1, DummyDT.INNER_2)));
+        Assert.assertEquals(nodes, Set.of(DummyDT.INNER_1, DummyDT.INNER_2));
     }
 
     @Test
     public void testTransformingLeafIterator() {
         final Set<String> nodes =
-                Sets.newHashSet(DiscriminationTreeIterators.transformingLeafIterator(DummyDT.DT.getRoot(),
-                                                                                     n -> String.valueOf(n.getData())));
+                IteratorUtil.set(DiscriminationTreeIterators.transformingLeafIterator(DummyDT.DT.getRoot(),
+                                                                                      n -> String.valueOf(n.getData())));
 
-        Assert.assertEquals(nodes, Sets.newHashSet("a", "b", "c"));
+        Assert.assertEquals(nodes, Set.of("a", "b", "c"));
     }
 }

--- a/datastructures/discrimination-tree/src/test/java/de/learnlib/datastructure/discriminationtree/VisualizationTest.java
+++ b/datastructures/discrimination-tree/src/test/java/de/learnlib/datastructure/discriminationtree/VisualizationTest.java
@@ -18,7 +18,6 @@ package de.learnlib.datastructure.discriminationtree;
 import java.io.IOException;
 import java.io.StringWriter;
 
-import com.google.common.io.CharStreams;
 import net.automatalib.common.util.IOUtil;
 import net.automatalib.serialization.dot.GraphDOT;
 import org.testng.Assert;
@@ -32,7 +31,7 @@ public class VisualizationTest {
         GraphDOT.write(DummyDT.DT, actualDT);
 
         final String expectedDT =
-                CharStreams.toString(IOUtil.asBufferedUTF8Reader(VisualizationTest.class.getResourceAsStream("/dt.dot")));
+                IOUtil.toString(IOUtil.asBufferedUTF8Reader(VisualizationTest.class.getResourceAsStream("/dt.dot")));
 
         Assert.assertEquals(actualDT.toString(), expectedDT);
     }

--- a/datastructures/list/pom.xml
+++ b/datastructures/list/pom.xml
@@ -33,11 +33,6 @@ limitations under the License.
     <dependencies>
         <!-- external -->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.checkerframework</groupId>
             <artifactId>checker-qual</artifactId>
         </dependency>

--- a/datastructures/list/src/main/java/de/learnlib/datastructure/list/IntrusiveList.java
+++ b/datastructures/list/src/main/java/de/learnlib/datastructure/list/IntrusiveList.java
@@ -16,8 +16,8 @@
 package de.learnlib.datastructure.list;
 
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
-import com.google.common.collect.AbstractIterator;
 import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -59,7 +59,7 @@ public class IntrusiveList<T extends IntrusiveListElem<T>> extends IntrusiveList
         return new ListIterator(next);
     }
 
-    private class ListIterator extends AbstractIterator<T> {
+    private class ListIterator implements Iterator<T> {
 
         private @Nullable T cursor;
 
@@ -68,9 +68,14 @@ public class IntrusiveList<T extends IntrusiveListElem<T>> extends IntrusiveList
         }
 
         @Override
-        protected @Nullable T computeNext() {
+        public boolean hasNext() {
+            return cursor != null;
+        }
+
+        @Override
+        public T next() {
             if (cursor == null) {
-                return endOfData();
+                throw new NoSuchElementException();
             }
 
             final T result = cursor;

--- a/datastructures/list/src/main/java/module-info.java
+++ b/datastructures/list/src/main/java/module-info.java
@@ -28,7 +28,6 @@
  */
 open module de.learnlib.datastructure.list {
 
-    requires com.google.common;
     requires org.checkerframework.checker.qual;
 
     exports de.learnlib.datastructure.list;

--- a/datastructures/observation-table/pom.xml
+++ b/datastructures/observation-table/pom.xml
@@ -39,11 +39,6 @@ limitations under the License.
 
         <!-- external -->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>net.automatalib</groupId>
             <artifactId>automata-api</artifactId>
         </dependency>
@@ -54,10 +49,6 @@ limitations under the License.
         <dependency>
             <groupId>net.automatalib</groupId>
             <artifactId>automata-commons-util</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>net.automatalib</groupId>
-            <artifactId>automata-commons-smartcollections</artifactId>
         </dependency>
 
         <dependency>

--- a/datastructures/observation-table/src/main/java/de/learnlib/datastructure/observationtable/RowImpl.java
+++ b/datastructures/observation-table/src/main/java/de/learnlib/datastructure/observationtable/RowImpl.java
@@ -15,7 +15,7 @@
  */
 package de.learnlib.datastructure.observationtable;
 
-import net.automatalib.common.smartcollection.ResizingArrayStorage;
+import net.automatalib.common.util.array.ResizingArrayStorage;
 import net.automatalib.word.Word;
 
 final class RowImpl<I> implements Row<I> {

--- a/datastructures/observation-table/src/main/java/de/learnlib/datastructure/observationtable/reader/SuffixASCIIReader.java
+++ b/datastructures/observation-table/src/main/java/de/learnlib/datastructure/observationtable/reader/SuffixASCIIReader.java
@@ -16,13 +16,14 @@
 package de.learnlib.datastructure.observationtable.reader;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import com.google.common.collect.Maps;
 import de.learnlib.datastructure.observationtable.ObservationTable;
 import net.automatalib.alphabet.Alphabet;
+import net.automatalib.common.util.HashUtil;
 import net.automatalib.word.Word;
 
 public class SuffixASCIIReader<I, D> implements ObservationTableReader<I, D> {
@@ -52,7 +53,7 @@ public class SuffixASCIIReader<I, D> implements ObservationTableReader<I, D> {
     }
 
     private Map<String, I> generateNameToSymbolMap(Alphabet<I> alphabet) {
-        Map<String, I> nameToSymbol = Maps.newHashMapWithExpectedSize(alphabet.size());
+        Map<String, I> nameToSymbol = new HashMap<>(HashUtil.capacity(alphabet.size()));
 
         for (I symbol : alphabet) {
             String symbolName = Objects.toString(symbol);

--- a/datastructures/observation-table/src/main/java/module-info.java
+++ b/datastructures/observation-table/src/main/java/module-info.java
@@ -28,10 +28,8 @@
  */
 open module de.learnlib.datastructure.observationtable {
 
-    requires com.google.common;
     requires de.learnlib.api;
     requires net.automatalib.api;
-    requires net.automatalib.common.smartcollection;
     requires net.automatalib.common.util;
     requires net.automatalib.core;
     requires org.checkerframework.checker.qual;

--- a/datastructures/observation-table/src/test/java/de/learnlib/datastructure/observationtable/MockedObservationTable.java
+++ b/datastructures/observation-table/src/test/java/de/learnlib/datastructure/observationtable/MockedObservationTable.java
@@ -22,7 +22,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.base.Preconditions;
 import de.learnlib.datastructure.observationtable.reader.SimpleObservationTable;
 import net.automatalib.word.Word;
 
@@ -62,7 +61,7 @@ public class MockedObservationTable<I, D> extends SimpleObservationTable<I, D> {
     }
 
     private RowImpl<I> addPrefix(Word<I> prefix, List<D> contents) {
-        Preconditions.checkArgument(getSuffixes().size() == contents.size());
+        assert getSuffixes().size() == contents.size();
 
         final RowImpl<I> row = new RowImpl<>(prefix, rows.size());
 

--- a/datastructures/pta/pom.xml
+++ b/datastructures/pta/pom.xml
@@ -33,11 +33,6 @@ limitations under the License.
     <dependencies>
         <!-- external -->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>net.automatalib</groupId>
             <artifactId>automata-api</artifactId>
         </dependency>

--- a/datastructures/pta/src/main/java/de/learnlib/datastructure/pta/AbstractBasePTAState.java
+++ b/datastructures/pta/src/main/java/de/learnlib/datastructure/pta/AbstractBasePTAState.java
@@ -18,7 +18,7 @@ package de.learnlib.datastructure.pta;
 import java.util.Objects;
 import java.util.function.Consumer;
 
-import net.automatalib.common.smartcollection.ArrayStorage;
+import net.automatalib.common.util.array.ArrayStorage;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 

--- a/datastructures/pta/src/main/java/de/learnlib/datastructure/pta/BasePTA.java
+++ b/datastructures/pta/src/main/java/de/learnlib/datastructure/pta/BasePTA.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import com.google.common.collect.AbstractIterator;
 import net.automatalib.alphabet.Alphabet;
 import net.automatalib.alphabet.impl.Alphabets;
 import net.automatalib.automaton.FiniteAlphabetAutomaton;
@@ -36,6 +35,7 @@ import net.automatalib.automaton.graph.TransitionEdge.Property;
 import net.automatalib.automaton.graph.UniversalAutomatonGraphView;
 import net.automatalib.automaton.visualization.AutomatonVisualizationHelper;
 import net.automatalib.common.smartcollection.IntSeq;
+import net.automatalib.common.util.collection.AbstractSimplifiedIterator;
 import net.automatalib.graph.UniversalGraph;
 import net.automatalib.visualization.VisualizationHelper;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -180,21 +180,21 @@ public class BasePTA<S extends AbstractBasePTAState<S, SP, TP>, SP, TP>
         bfsQueue.add(root);
         visited.add(root);
 
-        return new AbstractIterator<S>() {
+        return new AbstractSimplifiedIterator<S>() {
 
             @Override
-            protected S computeNext() {
-                S next = bfsQueue.poll();
-                if (next == null) {
-                    return endOfData();
+            protected boolean calculateNext() {
+                super.nextValue = bfsQueue.poll();
+                if (super.nextValue == null) {
+                    return false;
                 }
                 for (int i = 0; i < alphabetSize; i++) {
-                    S child = next.getSuccessor(i);
+                    S child = super.nextValue.getSuccessor(i);
                     if (child != null && visited.add(child)) {
                         bfsQueue.offer(child);
                     }
                 }
-                return next;
+                return true;
             }
         };
     }

--- a/datastructures/pta/src/main/java/de/learnlib/datastructure/pta/RedBlueMerge.java
+++ b/datastructures/pta/src/main/java/de/learnlib/datastructure/pta/RedBlueMerge.java
@@ -26,8 +26,8 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import net.automatalib.automaton.UniversalDeterministicAutomaton;
-import net.automatalib.common.smartcollection.ArrayStorage;
 import net.automatalib.common.util.Pair;
+import net.automatalib.common.util.array.ArrayStorage;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class RedBlueMerge<S extends AbstractBlueFringePTAState<S, SP, TP>, SP, TP> {

--- a/datastructures/pta/src/main/java/module-info.java
+++ b/datastructures/pta/src/main/java/module-info.java
@@ -28,7 +28,6 @@
  */
 open module de.learnlib.datastructure.pta {
 
-    requires com.google.common;
     requires net.automatalib.api;
     requires net.automatalib.common.smartcollection;
     requires net.automatalib.common.util;

--- a/datastructures/pta/src/test/java/de/learnlib/datastructure/pta/PTAVisualizationTest.java
+++ b/datastructures/pta/src/test/java/de/learnlib/datastructure/pta/PTAVisualizationTest.java
@@ -20,7 +20,6 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.google.common.io.CharStreams;
 import net.automatalib.alphabet.Alphabet;
 import net.automatalib.alphabet.impl.Alphabets;
 import net.automatalib.automaton.transducer.impl.CompactMoore;
@@ -71,7 +70,7 @@ public class PTAVisualizationTest {
         GraphDOT.write(this.pta, actualPTA);
 
         final String expectedPTA =
-                CharStreams.toString(IOUtil.asBufferedUTF8Reader(PTAVisualizationTest.class.getResourceAsStream(
+                IOUtil.toString(IOUtil.asBufferedUTF8Reader(PTAVisualizationTest.class.getResourceAsStream(
                         "/pta.dot")));
 
         Assert.assertEquals(actualPTA.toString(), expectedPTA);

--- a/examples/src/main/java/de/learnlib/example/parallelism/ParallelismExample1.java
+++ b/examples/src/main/java/de/learnlib/example/parallelism/ParallelismExample1.java
@@ -32,7 +32,7 @@ import de.learnlib.sul.SUL;
 import net.automatalib.alphabet.Alphabet;
 import net.automatalib.alphabet.impl.Alphabets;
 import net.automatalib.automaton.transducer.impl.CompactMealy;
-import net.automatalib.common.util.collection.CollectionsUtil;
+import net.automatalib.common.util.collection.IterableUtil;
 import net.automatalib.util.automaton.random.RandomAutomata;
 import net.automatalib.word.Word;
 
@@ -60,7 +60,7 @@ public class ParallelismExample1 {
 
         // generate 1 million (10^6) input words
         this.queries = new ArrayList<>((int) Math.pow(inputs.size(), QUERIES_EXP));
-        for (List<Integer> input : CollectionsUtil.allTuples(inputs, QUERIES_EXP)) {
+        for (List<Integer> input : IterableUtil.allTuples(inputs, QUERIES_EXP)) {
             queries.add(new DefaultQuery<>(Word.fromList(input)));
         }
     }

--- a/filters/cache/src/test/java/de/learnlib/filter/cache/AbstractParallelCacheTest.java
+++ b/filters/cache/src/test/java/de/learnlib/filter/cache/AbstractParallelCacheTest.java
@@ -23,7 +23,7 @@ import de.learnlib.oracle.EquivalenceOracle;
 import de.learnlib.oracle.ParallelOracle;
 import de.learnlib.query.DefaultQuery;
 import net.automatalib.alphabet.Alphabet;
-import net.automatalib.common.util.collection.CollectionsUtil;
+import net.automatalib.common.util.collection.IterableUtil;
 import net.automatalib.word.Word;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -81,7 +81,7 @@ public abstract class AbstractParallelCacheTest<A, I, D> {
 
         final List<CountingQuery<I, D>> queries = new ArrayList<>(numQueries);
 
-        for (List<I> word : CollectionsUtil.allTuples(alphabet, 0, MAXIMUM_LENGTH_OF_QUERIES)) {
+        for (List<I> word : IterableUtil.allTuples(alphabet, 0, MAXIMUM_LENGTH_OF_QUERIES)) {
             queries.add(new CountingQuery<>(Word.fromList(word)));
         }
 
@@ -111,9 +111,9 @@ public abstract class AbstractParallelCacheTest<A, I, D> {
         final List<DefaultQuery<I, D>> queries =
                 new ArrayList<>((int) Math.pow(alphabet.size(), MAXIMUM_LENGTH_OF_QUERIES));
 
-        for (List<I> word : CollectionsUtil.allTuples(alphabet,
-                                                            MAXIMUM_LENGTH_OF_QUERIES + 1,
-                                                            MAXIMUM_LENGTH_OF_QUERIES + 1)) {
+        for (List<I> word : IterableUtil.allTuples(alphabet,
+                                                   MAXIMUM_LENGTH_OF_QUERIES + 1,
+                                                   MAXIMUM_LENGTH_OF_QUERIES + 1)) {
             queries.add(new DefaultQuery<>(Word.fromList(word)));
         }
 

--- a/filters/statistics/pom.xml
+++ b/filters/statistics/pom.xml
@@ -55,12 +55,6 @@ limitations under the License.
 
         <!-- test -->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>de.learnlib</groupId>
             <artifactId>learnlib-drivers-simulator</artifactId>
             <scope>test</scope>

--- a/filters/statistics/src/test/java/de/learnlib/filter/statistic/TestQueries.java
+++ b/filters/statistics/src/test/java/de/learnlib/filter/statistic/TestQueries.java
@@ -24,7 +24,7 @@ import de.learnlib.query.Query;
 import net.automatalib.alphabet.Alphabet;
 import net.automatalib.alphabet.impl.Alphabets;
 import net.automatalib.automaton.transducer.impl.CompactMealy;
-import net.automatalib.common.util.collection.CollectionsUtil;
+import net.automatalib.common.util.collection.CollectionUtil;
 import net.automatalib.common.util.random.RandomUtil;
 import net.automatalib.util.automaton.random.RandomAutomata;
 import net.automatalib.word.Word;
@@ -60,7 +60,7 @@ public final class TestQueries {
                                                                    Collection<I> inputs) {
 
         final Random r = new Random(42);
-        final List<? extends I> inputsAsList = CollectionsUtil.randomAccessList(inputs);
+        final List<? extends I> inputsAsList = CollectionUtil.randomAccessList(inputs);
 
         List<Query<I, D>> result = new ArrayList<>(numQueries);
         for (int i = 0; i < numQueries; i++) {

--- a/filters/statistics/src/test/java/de/learnlib/filter/statistic/oracle/HistogramOracleTest.java
+++ b/filters/statistics/src/test/java/de/learnlib/filter/statistic/oracle/HistogramOracleTest.java
@@ -20,7 +20,6 @@ import java.io.InputStream;
 import java.util.Collection;
 import java.util.Collections;
 
-import com.google.common.io.CharStreams;
 import de.learnlib.filter.statistic.TestQueries;
 import de.learnlib.oracle.MembershipOracle;
 import de.learnlib.query.Query;
@@ -76,8 +75,8 @@ public class HistogramOracleTest {
         try (InputStream detailStream = HistogramOracleTest.class.getResourceAsStream("/histogram_details.txt");
              InputStream summaryStream = HistogramOracleTest.class.getResourceAsStream("/histogram_summary.txt")) {
 
-            final String expectedDetail = CharStreams.toString(IOUtil.asBufferedUTF8Reader(detailStream));
-            final String expectedSummary = CharStreams.toString(IOUtil.asBufferedUTF8Reader(summaryStream));
+            final String expectedDetail = IOUtil.toString(IOUtil.asBufferedUTF8Reader(detailStream));
+            final String expectedSummary = IOUtil.toString(IOUtil.asBufferedUTF8Reader(summaryStream));
 
             Assert.assertEquals(details, expectedDetail);
             Assert.assertEquals(summary, expectedSummary);

--- a/oracles/equivalence-oracles/pom.xml
+++ b/oracles/equivalence-oracles/pom.xml
@@ -43,11 +43,6 @@ limitations under the License.
 
         <!-- external -->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>net.automatalib</groupId>
             <artifactId>automata-api</artifactId>
         </dependency>

--- a/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/AbstractTestWordEQOracle.java
+++ b/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/AbstractTestWordEQOracle.java
@@ -20,14 +20,12 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Iterators;
-import com.google.common.collect.Streams;
 import de.learnlib.logging.Category;
 import de.learnlib.oracle.EquivalenceOracle;
 import de.learnlib.oracle.MembershipOracle;
 import de.learnlib.query.DefaultQuery;
 import net.automatalib.automaton.concept.Output;
+import net.automatalib.common.util.collection.IteratorUtil;
 import net.automatalib.word.Word;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
@@ -59,7 +57,7 @@ public abstract class AbstractTestWordEQOracle<A extends Output<I, D>, I, D> imp
     }
 
     public AbstractTestWordEQOracle(MembershipOracle<I, D> membershipOracle, int batchSize) {
-        Preconditions.checkArgument(batchSize > 0);
+        assert batchSize > 0;
 
         this.membershipOracle = membershipOracle;
         this.batchSize = batchSize;
@@ -102,9 +100,9 @@ public abstract class AbstractTestWordEQOracle<A extends Output<I, D>, I, D> imp
 
     private Stream<DefaultQuery<I, D>> answerQueries(Stream<DefaultQuery<I, D>> stream) {
         if (isBatched()) {
-            return Streams.stream(Iterators.partition(stream.iterator(), this.batchSize))
-                          .peek(membershipOracle::processQueries)
-                          .flatMap(List::stream);
+            return IteratorUtil.stream(IteratorUtil.batch(stream.iterator(), this.batchSize))
+                               .peek(membershipOracle::processQueries)
+                               .flatMap(List::stream);
         } else {
             return stream.peek(membershipOracle::processQuery);
         }

--- a/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/CompleteExplorationEQOracle.java
+++ b/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/CompleteExplorationEQOracle.java
@@ -18,7 +18,6 @@ package de.learnlib.oracle.equivalence;
 import java.util.Collection;
 import java.util.stream.Stream;
 
-import com.google.common.collect.Streams;
 import de.learnlib.oracle.EquivalenceOracle.DFAEquivalenceOracle;
 import de.learnlib.oracle.EquivalenceOracle.MealyEquivalenceOracle;
 import de.learnlib.oracle.EquivalenceOracle.MooreEquivalenceOracle;
@@ -35,6 +34,7 @@ import net.automatalib.automaton.fsa.DFA;
 import net.automatalib.automaton.transducer.MealyMachine;
 import net.automatalib.automaton.transducer.MooreMachine;
 import net.automatalib.common.util.collection.CollectionsUtil;
+import net.automatalib.common.util.collection.IterableUtil;
 import net.automatalib.word.Word;
 
 /**
@@ -128,6 +128,6 @@ public class CompleteExplorationEQOracle<A extends Output<I, D>, I, D> extends A
 
     @Override
     protected Stream<Word<I>> generateTestWords(A hypothesis, Collection<? extends I> inputs) {
-        return Streams.stream(CollectionsUtil.allTuples(inputs, minDepth, maxDepth)).map(Word::fromList);
+        return IterableUtil.stream(CollectionsUtil.allTuples(inputs, minDepth, maxDepth)).map(Word::fromList);
     }
 }

--- a/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/CompleteExplorationEQOracle.java
+++ b/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/CompleteExplorationEQOracle.java
@@ -33,7 +33,6 @@ import net.automatalib.automaton.concept.Output;
 import net.automatalib.automaton.fsa.DFA;
 import net.automatalib.automaton.transducer.MealyMachine;
 import net.automatalib.automaton.transducer.MooreMachine;
-import net.automatalib.common.util.collection.CollectionsUtil;
 import net.automatalib.common.util.collection.IterableUtil;
 import net.automatalib.word.Word;
 
@@ -128,6 +127,6 @@ public class CompleteExplorationEQOracle<A extends Output<I, D>, I, D> extends A
 
     @Override
     protected Stream<Word<I>> generateTestWords(A hypothesis, Collection<? extends I> inputs) {
-        return IterableUtil.stream(CollectionsUtil.allTuples(inputs, minDepth, maxDepth)).map(Word::fromList);
+        return IterableUtil.stream(IterableUtil.allTuples(inputs, minDepth, maxDepth)).map(Word::fromList);
     }
 }

--- a/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/IncrementalWMethodEQOracle.java
+++ b/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/IncrementalWMethodEQOracle.java
@@ -18,7 +18,6 @@ package de.learnlib.oracle.equivalence;
 import java.util.Collection;
 import java.util.stream.Stream;
 
-import com.google.common.collect.Streams;
 import de.learnlib.oracle.EquivalenceOracle.DFAEquivalenceOracle;
 import de.learnlib.oracle.EquivalenceOracle.MealyEquivalenceOracle;
 import de.learnlib.oracle.EquivalenceOracle.MooreEquivalenceOracle;
@@ -36,6 +35,7 @@ import net.automatalib.automaton.concept.Output;
 import net.automatalib.automaton.fsa.DFA;
 import net.automatalib.automaton.transducer.MealyMachine;
 import net.automatalib.automaton.transducer.MooreMachine;
+import net.automatalib.common.util.collection.IteratorUtil;
 import net.automatalib.util.automaton.conformance.IncrementalWMethodTestsIterator;
 import net.automatalib.word.Word;
 
@@ -106,6 +106,6 @@ public class IncrementalWMethodEQOracle<A extends UniversalDeterministicAutomato
         // FIXME: warn about inputs being ignored?
         incrementalWMethodIt.update(hypothesis);
 
-        return Streams.stream(incrementalWMethodIt);
+        return IteratorUtil.stream(incrementalWMethodIt);
     }
 }

--- a/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/RandomWordsEQOracle.java
+++ b/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/RandomWordsEQOracle.java
@@ -35,7 +35,7 @@ import net.automatalib.automaton.concept.Output;
 import net.automatalib.automaton.fsa.DFA;
 import net.automatalib.automaton.transducer.MealyMachine;
 import net.automatalib.automaton.transducer.MooreMachine;
-import net.automatalib.common.util.collection.CollectionsUtil;
+import net.automatalib.common.util.collection.CollectionUtil;
 import net.automatalib.word.Word;
 import net.automatalib.word.WordBuilder;
 
@@ -105,7 +105,7 @@ public class RandomWordsEQOracle<A extends Output<I, D>, I, D> extends AbstractT
     @Override
     protected Stream<Word<I>> generateTestWords(A hypothesis, Collection<? extends I> inputs) {
 
-        final List<? extends I> symbolList = CollectionsUtil.randomAccessList(inputs);
+        final List<? extends I> symbolList = CollectionUtil.randomAccessList(inputs);
 
         return Stream.generate(() -> generateTestWord(symbolList, symbolList.size())).limit(maxTests);
     }

--- a/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/WMethodEQOracle.java
+++ b/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/WMethodEQOracle.java
@@ -18,7 +18,6 @@ package de.learnlib.oracle.equivalence;
 import java.util.Collection;
 import java.util.stream.Stream;
 
-import com.google.common.collect.Streams;
 import de.learnlib.oracle.EquivalenceOracle.DFAEquivalenceOracle;
 import de.learnlib.oracle.EquivalenceOracle.MealyEquivalenceOracle;
 import de.learnlib.oracle.EquivalenceOracle.MooreEquivalenceOracle;
@@ -35,6 +34,7 @@ import net.automatalib.automaton.concept.Output;
 import net.automatalib.automaton.fsa.DFA;
 import net.automatalib.automaton.transducer.MealyMachine;
 import net.automatalib.automaton.transducer.MooreMachine;
+import net.automatalib.common.util.collection.IteratorUtil;
 import net.automatalib.util.automaton.conformance.WMethodTestsIterator;
 import net.automatalib.word.Word;
 
@@ -141,8 +141,9 @@ public class WMethodEQOracle<A extends UniversalDeterministicAutomaton<?, I, ?, 
 
     @Override
     protected Stream<Word<I>> generateTestWords(A hypothesis, Collection<? extends I> inputs) {
-        return Streams.stream(new WMethodTestsIterator<>(hypothesis,
-                                                         inputs,
-                                                         Math.max(lookahead, expectedSize - hypothesis.size())));
+        return IteratorUtil.stream(new WMethodTestsIterator<>(hypothesis,
+                                                              inputs,
+                                                              Math.max(lookahead,
+                                                                          expectedSize - hypothesis.size())));
     }
 }

--- a/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/WMethodEQOracle.java
+++ b/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/WMethodEQOracle.java
@@ -143,7 +143,6 @@ public class WMethodEQOracle<A extends UniversalDeterministicAutomaton<?, I, ?, 
     protected Stream<Word<I>> generateTestWords(A hypothesis, Collection<? extends I> inputs) {
         return IteratorUtil.stream(new WMethodTestsIterator<>(hypothesis,
                                                               inputs,
-                                                              Math.max(lookahead,
-                                                                          expectedSize - hypothesis.size())));
+                                                              Math.max(lookahead, expectedSize - hypothesis.size())));
     }
 }

--- a/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/WpMethodEQOracle.java
+++ b/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/WpMethodEQOracle.java
@@ -142,7 +142,6 @@ public class WpMethodEQOracle<A extends UniversalDeterministicAutomaton<?, I, ?,
     protected Stream<Word<I>> generateTestWords(A hypothesis, Collection<? extends I> inputs) {
         return IteratorUtil.stream(new WpMethodTestsIterator<>(hypothesis,
                                                                inputs,
-                                                               Math.max(lookahead,
-                                                                           expectedSize - hypothesis.size())));
+                                                               Math.max(lookahead, expectedSize - hypothesis.size())));
     }
 }

--- a/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/WpMethodEQOracle.java
+++ b/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/WpMethodEQOracle.java
@@ -18,7 +18,6 @@ package de.learnlib.oracle.equivalence;
 import java.util.Collection;
 import java.util.stream.Stream;
 
-import com.google.common.collect.Streams;
 import de.learnlib.oracle.EquivalenceOracle.DFAEquivalenceOracle;
 import de.learnlib.oracle.EquivalenceOracle.MealyEquivalenceOracle;
 import de.learnlib.oracle.EquivalenceOracle.MooreEquivalenceOracle;
@@ -35,6 +34,7 @@ import net.automatalib.automaton.concept.Output;
 import net.automatalib.automaton.fsa.DFA;
 import net.automatalib.automaton.transducer.MealyMachine;
 import net.automatalib.automaton.transducer.MooreMachine;
+import net.automatalib.common.util.collection.IteratorUtil;
 import net.automatalib.util.automaton.conformance.WpMethodTestsIterator;
 import net.automatalib.word.Word;
 
@@ -140,8 +140,9 @@ public class WpMethodEQOracle<A extends UniversalDeterministicAutomaton<?, I, ?,
 
     @Override
     protected Stream<Word<I>> generateTestWords(A hypothesis, Collection<? extends I> inputs) {
-        return Streams.stream(new WpMethodTestsIterator<>(hypothesis,
-                                                          inputs,
-                                                          Math.max(lookahead, expectedSize - hypothesis.size())));
+        return IteratorUtil.stream(new WpMethodTestsIterator<>(hypothesis,
+                                                               inputs,
+                                                               Math.max(lookahead,
+                                                                           expectedSize - hypothesis.size())));
     }
 }

--- a/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/mealy/RandomWalkEQOracle.java
+++ b/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/mealy/RandomWalkEQOracle.java
@@ -25,7 +25,7 @@ import de.learnlib.oracle.EquivalenceOracle.MealyEquivalenceOracle;
 import de.learnlib.query.DefaultQuery;
 import de.learnlib.sul.SUL;
 import net.automatalib.automaton.transducer.MealyMachine;
-import net.automatalib.common.util.collection.CollectionsUtil;
+import net.automatalib.common.util.collection.CollectionUtil;
 import net.automatalib.word.Word;
 import net.automatalib.word.WordBuilder;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -107,7 +107,7 @@ public class RandomWalkEQOracle<I, O> implements MealyEquivalenceOracle<I, O> {
             return null;
         }
 
-        List<? extends I> choices = CollectionsUtil.randomAccessList(inputs);
+        List<? extends I> choices = CollectionUtil.randomAccessList(inputs);
         int bound = choices.size();
         S cur = hypothesis.getInitialState();
         WordBuilder<I> wbIn = new WordBuilder<>();

--- a/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/sba/WMethodEQOracle.java
+++ b/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/sba/WMethodEQOracle.java
@@ -18,12 +18,12 @@ package de.learnlib.oracle.equivalence.sba;
 import java.util.Collection;
 import java.util.stream.Stream;
 
-import com.google.common.collect.Streams;
 import de.learnlib.oracle.MembershipOracle;
 import de.learnlib.oracle.equivalence.AbstractTestWordEQOracle;
 import net.automatalib.alphabet.ProceduralInputAlphabet;
 import net.automatalib.automaton.concept.FiniteRepresentation;
 import net.automatalib.automaton.procedural.SBA;
+import net.automatalib.common.util.collection.IteratorUtil;
 import net.automatalib.util.automaton.conformance.SBAWMethodTestsIterator;
 import net.automatalib.util.automaton.conformance.WMethodTestsIterator;
 import net.automatalib.word.Word;
@@ -101,8 +101,9 @@ public class WMethodEQOracle<I> extends AbstractTestWordEQOracle<SBA<?, I>, I, B
         @SuppressWarnings("unchecked")
         final ProceduralInputAlphabet<I> alphabet = (ProceduralInputAlphabet<I>) inputs;
 
-        return Streams.stream(new SBAWMethodTestsIterator<>(hypothesis,
-                                                            alphabet,
-                                                            Math.max(lookahead, expectedSize - hypothesis.size())));
+        return IteratorUtil.stream(new SBAWMethodTestsIterator<>(hypothesis,
+                                                                 alphabet,
+                                                                 Math.max(lookahead,
+                                                                             expectedSize - hypothesis.size())));
     }
 }

--- a/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/sba/WMethodEQOracle.java
+++ b/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/sba/WMethodEQOracle.java
@@ -104,6 +104,6 @@ public class WMethodEQOracle<I> extends AbstractTestWordEQOracle<SBA<?, I>, I, B
         return IteratorUtil.stream(new SBAWMethodTestsIterator<>(hypothesis,
                                                                  alphabet,
                                                                  Math.max(lookahead,
-                                                                             expectedSize - hypothesis.size())));
+                                                                          expectedSize - hypothesis.size())));
     }
 }

--- a/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/spa/WMethodEQOracle.java
+++ b/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/spa/WMethodEQOracle.java
@@ -104,9 +104,9 @@ public class WMethodEQOracle<I> extends AbstractTestWordEQOracle<SPA<?, I>, I, B
         return IteratorUtil.stream(new SPATestsIterator<>(hypothesis,
                                                           alphabet,
                                                           (dfa, alph) -> new WMethodTestsIterator<>(dfa,
-                                                                                               alph,
-                                                                                               Math.max(lookahead,
-                                                                                                        expectedSize -
-                                                                                                        dfa.size()))));
+                                                                                                    alph,
+                                                                                                    Math.max(lookahead,
+                                                                                                             expectedSize -
+                                                                                                             dfa.size()))));
     }
 }

--- a/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/spa/WMethodEQOracle.java
+++ b/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/spa/WMethodEQOracle.java
@@ -18,12 +18,12 @@ package de.learnlib.oracle.equivalence.spa;
 import java.util.Collection;
 import java.util.stream.Stream;
 
-import com.google.common.collect.Streams;
 import de.learnlib.oracle.MembershipOracle;
 import de.learnlib.oracle.equivalence.AbstractTestWordEQOracle;
 import net.automatalib.alphabet.ProceduralInputAlphabet;
 import net.automatalib.automaton.fsa.DFA;
 import net.automatalib.automaton.procedural.SPA;
+import net.automatalib.common.util.collection.IteratorUtil;
 import net.automatalib.util.automaton.conformance.SPATestsIterator;
 import net.automatalib.util.automaton.conformance.WMethodTestsIterator;
 import net.automatalib.word.Word;
@@ -101,9 +101,9 @@ public class WMethodEQOracle<I> extends AbstractTestWordEQOracle<SPA<?, I>, I, B
         @SuppressWarnings("unchecked")
         final ProceduralInputAlphabet<I> alphabet = (ProceduralInputAlphabet<I>) inputs;
 
-        return Streams.stream(new SPATestsIterator<>(hypothesis,
-                                                     alphabet,
-                                                     (dfa, alph) -> new WMethodTestsIterator<>(dfa,
+        return IteratorUtil.stream(new SPATestsIterator<>(hypothesis,
+                                                          alphabet,
+                                                          (dfa, alph) -> new WMethodTestsIterator<>(dfa,
                                                                                                alph,
                                                                                                Math.max(lookahead,
                                                                                                         expectedSize -

--- a/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/spa/WpMethodEQOracle.java
+++ b/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/spa/WpMethodEQOracle.java
@@ -105,10 +105,9 @@ public class WpMethodEQOracle<I> extends AbstractTestWordEQOracle<SPA<?, I>, I, 
         return IteratorUtil.stream(new SPATestsIterator<>(hypothesis,
                                                           alphabet,
                                                           (dfa, alph) -> new WpMethodTestsIterator<>(dfa,
-                                                                                                        alph,
-                                                                                                        Math.max(
-                                                                                                                lookahead,
-                                                                                                                expectedSize -
-                                                                                                                dfa.size()))));
+                                                                                                     alph,
+                                                                                                     Math.max(lookahead,
+                                                                                                              expectedSize -
+                                                                                                              dfa.size()))));
     }
 }

--- a/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/spa/WpMethodEQOracle.java
+++ b/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/spa/WpMethodEQOracle.java
@@ -18,12 +18,12 @@ package de.learnlib.oracle.equivalence.spa;
 import java.util.Collection;
 import java.util.stream.Stream;
 
-import com.google.common.collect.Streams;
 import de.learnlib.oracle.MembershipOracle;
 import de.learnlib.oracle.equivalence.AbstractTestWordEQOracle;
 import net.automatalib.alphabet.ProceduralInputAlphabet;
 import net.automatalib.automaton.fsa.DFA;
 import net.automatalib.automaton.procedural.SPA;
+import net.automatalib.common.util.collection.IteratorUtil;
 import net.automatalib.util.automaton.conformance.SPATestsIterator;
 import net.automatalib.util.automaton.conformance.WMethodTestsIterator;
 import net.automatalib.util.automaton.conformance.WpMethodTestsIterator;
@@ -102,12 +102,13 @@ public class WpMethodEQOracle<I> extends AbstractTestWordEQOracle<SPA<?, I>, I, 
         @SuppressWarnings("unchecked")
         final ProceduralInputAlphabet<I> alphabet = (ProceduralInputAlphabet<I>) inputs;
 
-        return Streams.stream(new SPATestsIterator<>(hypothesis,
-                                                     alphabet,
-                                                     (dfa, alph) -> new WpMethodTestsIterator<>(dfa,
-                                                                                                alph,
-                                                                                                Math.max(lookahead,
-                                                                                                         expectedSize -
-                                                                                                         dfa.size()))));
+        return IteratorUtil.stream(new SPATestsIterator<>(hypothesis,
+                                                          alphabet,
+                                                          (dfa, alph) -> new WpMethodTestsIterator<>(dfa,
+                                                                                                        alph,
+                                                                                                        Math.max(
+                                                                                                                lookahead,
+                                                                                                                expectedSize -
+                                                                                                                dfa.size()))));
     }
 }

--- a/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/spmm/WMethodEQOracle.java
+++ b/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/spmm/WMethodEQOracle.java
@@ -105,6 +105,6 @@ public class WMethodEQOracle<I, O> extends AbstractTestWordEQOracle<SPMM<?, I, ?
         return IteratorUtil.stream(new SPMMWMethodTestsIterator<>(hypothesis,
                                                                   alphabet,
                                                                   Math.max(lookahead,
-                                                                              expectedSize - hypothesis.size())));
+                                                                           expectedSize - hypothesis.size())));
     }
 }

--- a/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/spmm/WMethodEQOracle.java
+++ b/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/spmm/WMethodEQOracle.java
@@ -18,13 +18,13 @@ package de.learnlib.oracle.equivalence.spmm;
 import java.util.Collection;
 import java.util.stream.Stream;
 
-import com.google.common.collect.Streams;
 import de.learnlib.oracle.MembershipOracle;
 import de.learnlib.oracle.equivalence.AbstractTestWordEQOracle;
 import net.automatalib.alphabet.ProceduralInputAlphabet;
 import net.automatalib.automaton.concept.FiniteRepresentation;
 import net.automatalib.automaton.procedural.SBA;
 import net.automatalib.automaton.procedural.SPMM;
+import net.automatalib.common.util.collection.IteratorUtil;
 import net.automatalib.util.automaton.conformance.SPMMWMethodTestsIterator;
 import net.automatalib.util.automaton.conformance.WMethodTestsIterator;
 import net.automatalib.word.Word;
@@ -102,8 +102,9 @@ public class WMethodEQOracle<I, O> extends AbstractTestWordEQOracle<SPMM<?, I, ?
         @SuppressWarnings("unchecked")
         final ProceduralInputAlphabet<I> alphabet = (ProceduralInputAlphabet<I>) inputs;
 
-        return Streams.stream(new SPMMWMethodTestsIterator<>(hypothesis,
-                                                             alphabet,
-                                                             Math.max(lookahead, expectedSize - hypothesis.size())));
+        return IteratorUtil.stream(new SPMMWMethodTestsIterator<>(hypothesis,
+                                                                  alphabet,
+                                                                  Math.max(lookahead,
+                                                                              expectedSize - hypothesis.size())));
     }
 }

--- a/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/vpa/RandomWellMatchedWordsEQOracle.java
+++ b/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/vpa/RandomWellMatchedWordsEQOracle.java
@@ -19,7 +19,6 @@ import java.util.Collection;
 import java.util.Random;
 import java.util.stream.Stream;
 
-import com.google.common.base.Preconditions;
 import de.learnlib.oracle.MembershipOracle;
 import de.learnlib.oracle.equivalence.AbstractTestWordEQOracle;
 import net.automatalib.alphabet.VPAlphabet;
@@ -59,7 +58,9 @@ public class RandomWellMatchedWordsEQOracle<I> extends AbstractTestWordEQOracle<
                                           int batchSize) {
         super(oracle, batchSize);
 
-        Preconditions.checkArgument(minLength <= maxLength, "minLength is smaller than maxLength");
+        if (minLength > maxLength) {
+            throw new IllegalArgumentException("minLength is smaller than maxLength");
+        }
 
         this.random = random;
         this.callProb = callProb;

--- a/oracles/equivalence-oracles/src/main/java/module-info.java
+++ b/oracles/equivalence-oracles/src/main/java/module-info.java
@@ -28,7 +28,6 @@
  */
 open module de.learnlib.oracle.equivalence {
 
-    requires com.google.common;
     requires de.learnlib.api;
     requires de.learnlib.common.util;
     requires net.automatalib.api;

--- a/oracles/equivalence-oracles/src/test/java/de/learnlib/oracle/equivalence/CExFirstOracleTest.java
+++ b/oracles/equivalence-oracles/src/test/java/de/learnlib/oracle/equivalence/CExFirstOracleTest.java
@@ -15,9 +15,9 @@
  */
 package de.learnlib.oracle.equivalence;
 
+import java.util.Arrays;
 import java.util.Collection;
 
-import com.google.common.collect.Lists;
 import de.learnlib.oracle.BlackBoxOracle;
 import de.learnlib.oracle.PropertyOracle;
 import de.learnlib.query.DefaultQuery;
@@ -61,7 +61,7 @@ public class CExFirstOracleTest {
         Mockito.when(query.getOutput()).thenReturn(Boolean.TRUE);
         Mockito.when(automaton.computeOutput(Mockito.any())).thenReturn(Boolean.FALSE);
 
-        oracle = new CExFirstOracle<>(Lists.newArrayList(po1, po2));
+        oracle = new CExFirstOracle<>(Arrays.asList(po1, po2));
         Mockito.when(po1.findCounterExample(automaton, inputs)).thenCallRealMethod();
         Mockito.when(po1.doFindCounterExample(automaton, inputs)).thenReturn(query);
         Mockito.when(po2.findCounterExample(automaton, inputs)).thenCallRealMethod();

--- a/oracles/equivalence-oracles/src/test/java/de/learnlib/oracle/equivalence/DisproveFirstOracleTest.java
+++ b/oracles/equivalence-oracles/src/test/java/de/learnlib/oracle/equivalence/DisproveFirstOracleTest.java
@@ -15,9 +15,9 @@
  */
 package de.learnlib.oracle.equivalence;
 
+import java.util.Arrays;
 import java.util.Collection;
 
-import com.google.common.collect.Lists;
 import de.learnlib.oracle.BlackBoxOracle;
 import de.learnlib.oracle.PropertyOracle;
 import de.learnlib.query.DefaultQuery;
@@ -61,7 +61,7 @@ public class DisproveFirstOracleTest {
         Mockito.when(query.getOutput()).thenReturn(Boolean.TRUE);
         Mockito.when(automaton.computeOutput(Mockito.any())).thenReturn(Boolean.FALSE);
 
-        oracle = new DisproveFirstOracle<>(Lists.newArrayList(po1, po2));
+        oracle = new DisproveFirstOracle<>(Arrays.asList(po1, po2));
         Mockito.when(po1.findCounterExample(automaton, inputs)).thenCallRealMethod();
         Mockito.when(po1.doFindCounterExample(automaton, inputs)).thenReturn(query);
         Mockito.when(po2.findCounterExample(automaton, inputs)).thenCallRealMethod();

--- a/oracles/equivalence-oracles/src/test/java/de/learnlib/oracle/equivalence/sba/WMethodEQOracleTest.java
+++ b/oracles/equivalence-oracles/src/test/java/de/learnlib/oracle/equivalence/sba/WMethodEQOracleTest.java
@@ -19,12 +19,12 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 
-import com.google.common.collect.Streams;
 import de.learnlib.oracle.membership.SimulatorOracle;
 import net.automatalib.alphabet.ProceduralInputAlphabet;
 import net.automatalib.alphabet.impl.Alphabets;
 import net.automatalib.alphabet.impl.DefaultProceduralInputAlphabet;
 import net.automatalib.automaton.procedural.SBA;
+import net.automatalib.common.util.collection.IteratorUtil;
 import net.automatalib.util.automaton.conformance.SBAWMethodTestsIterator;
 import net.automatalib.util.automaton.random.RandomAutomata;
 import net.automatalib.word.Word;
@@ -47,7 +47,7 @@ public class WMethodEQOracleTest {
 
         final List<Word<Character>> eqWords = oracle.generateTestWords(sba, alphabet).collect(Collectors.toList());
         final List<Word<Character>> testWords =
-                Streams.stream(new SBAWMethodTestsIterator<>(sba, alphabet, lookahead)).collect(Collectors.toList());
+                IteratorUtil.list(new SBAWMethodTestsIterator<>(sba, alphabet, lookahead));
 
         Assert.assertEquals(eqWords, testWords);
     }

--- a/oracles/equivalence-oracles/src/test/java/de/learnlib/oracle/equivalence/spa/WMethodEQOracleTest.java
+++ b/oracles/equivalence-oracles/src/test/java/de/learnlib/oracle/equivalence/spa/WMethodEQOracleTest.java
@@ -19,12 +19,12 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 
-import com.google.common.collect.Streams;
 import de.learnlib.oracle.membership.SimulatorOracle;
 import net.automatalib.alphabet.ProceduralInputAlphabet;
 import net.automatalib.alphabet.impl.Alphabets;
 import net.automatalib.alphabet.impl.DefaultProceduralInputAlphabet;
 import net.automatalib.automaton.procedural.SPA;
+import net.automatalib.common.util.collection.IteratorUtil;
 import net.automatalib.util.automaton.conformance.SPATestsIterator;
 import net.automatalib.util.automaton.conformance.WMethodTestsIterator;
 import net.automatalib.util.automaton.random.RandomAutomata;
@@ -47,12 +47,12 @@ public class WMethodEQOracleTest {
         final WMethodEQOracle<Character> oracle = new WMethodEQOracle<>(new SimulatorOracle<>(spa), lookahead);
 
         final List<Word<Character>> eqWords = oracle.generateTestWords(spa, alphabet).collect(Collectors.toList());
-        final List<Word<Character>> testWords = Streams.stream(new SPATestsIterator<>(spa,
-                                                                                      (dfa, alph) -> new WMethodTestsIterator<>(
+        final List<Word<Character>> testWords = IteratorUtil.stream(new SPATestsIterator<>(spa,
+                                                                                           (dfa, alph) -> new WMethodTestsIterator<>(
                                                                                               dfa,
                                                                                               alph,
                                                                                               lookahead)))
-                                                       .collect(Collectors.toList());
+                                                            .collect(Collectors.toList());
 
         Assert.assertEquals(eqWords, testWords);
     }

--- a/oracles/equivalence-oracles/src/test/java/de/learnlib/oracle/equivalence/spa/WpMethodEQOracleTest.java
+++ b/oracles/equivalence-oracles/src/test/java/de/learnlib/oracle/equivalence/spa/WpMethodEQOracleTest.java
@@ -19,12 +19,12 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 
-import com.google.common.collect.Streams;
 import de.learnlib.oracle.membership.SimulatorOracle;
 import net.automatalib.alphabet.ProceduralInputAlphabet;
 import net.automatalib.alphabet.impl.Alphabets;
 import net.automatalib.alphabet.impl.DefaultProceduralInputAlphabet;
 import net.automatalib.automaton.procedural.SPA;
+import net.automatalib.common.util.collection.IteratorUtil;
 import net.automatalib.util.automaton.conformance.SPATestsIterator;
 import net.automatalib.util.automaton.conformance.WpMethodTestsIterator;
 import net.automatalib.util.automaton.random.RandomAutomata;
@@ -47,12 +47,12 @@ public class WpMethodEQOracleTest {
         final WpMethodEQOracle<Character> oracle = new WpMethodEQOracle<>(new SimulatorOracle<>(spa), lookahead);
 
         final List<Word<Character>> eqWords = oracle.generateTestWords(spa, alphabet).collect(Collectors.toList());
-        final List<Word<Character>> testWords = Streams.stream(new SPATestsIterator<>(spa,
-                                                                                      (dfa, alph) -> new WpMethodTestsIterator<>(
-                                                                                              dfa,
-                                                                                              alph,
-                                                                                              lookahead)))
-                                                       .collect(Collectors.toList());
+        final List<Word<Character>> testWords = IteratorUtil.stream(new SPATestsIterator<>(spa,
+                                                                                           (dfa, alph) -> new WpMethodTestsIterator<>(
+                                                                                                      dfa,
+                                                                                                      alph,
+                                                                                                      lookahead)))
+                                                            .collect(Collectors.toList());
 
         Assert.assertEquals(eqWords, testWords);
     }

--- a/oracles/equivalence-oracles/src/test/java/de/learnlib/oracle/equivalence/spmm/WMethodEQOracleTest.java
+++ b/oracles/equivalence-oracles/src/test/java/de/learnlib/oracle/equivalence/spmm/WMethodEQOracleTest.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 
-import com.google.common.collect.Streams;
 import de.learnlib.oracle.membership.SimulatorOracle;
 import net.automatalib.alphabet.ProceduralInputAlphabet;
 import net.automatalib.alphabet.ProceduralOutputAlphabet;
@@ -27,6 +26,7 @@ import net.automatalib.alphabet.impl.Alphabets;
 import net.automatalib.alphabet.impl.DefaultProceduralInputAlphabet;
 import net.automatalib.alphabet.impl.DefaultProceduralOutputAlphabet;
 import net.automatalib.automaton.procedural.SPMM;
+import net.automatalib.common.util.collection.IteratorUtil;
 import net.automatalib.util.automaton.conformance.SPMMWMethodTestsIterator;
 import net.automatalib.util.automaton.random.RandomAutomata;
 import net.automatalib.word.Word;
@@ -54,8 +54,7 @@ public class WMethodEQOracleTest {
         final List<Word<Character>> eqWords =
                 oracle.generateTestWords(spmm, inputAlphabet).collect(Collectors.toList());
         final List<Word<Character>> testWords =
-                Streams.stream(new SPMMWMethodTestsIterator<>(spmm, inputAlphabet, lookahead))
-                       .collect(Collectors.toList());
+                IteratorUtil.list(new SPMMWMethodTestsIterator<>(spmm, inputAlphabet, lookahead));
 
         Assert.assertEquals(eqWords, testWords);
     }

--- a/oracles/parallelism/pom.xml
+++ b/oracles/parallelism/pom.xml
@@ -47,21 +47,12 @@ limitations under the License.
 
         <!-- external -->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>net.automatalib</groupId>
             <artifactId>automata-api</artifactId>
         </dependency>
         <dependency>
             <groupId>net.automatalib</groupId>
             <artifactId>automata-commons-util</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>net.automatalib</groupId>
-            <artifactId>automata-commons-smartcollections</artifactId>
         </dependency>
 
         <dependency>

--- a/oracles/parallelism/src/main/java/de/learnlib/oracle/parallelism/AbstractDynamicBatchProcessor.java
+++ b/oracles/parallelism/src/main/java/de/learnlib/oracle/parallelism/AbstractDynamicBatchProcessor.java
@@ -23,12 +23,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.function.Supplier;
 
-import com.google.common.base.Throwables;
 import de.learnlib.exception.BatchInterruptedException;
 import de.learnlib.oracle.BatchProcessor;
 import de.learnlib.oracle.ThreadPool;
 import de.learnlib.setting.LearnLibProperty;
 import de.learnlib.setting.LearnLibSettings;
+import net.automatalib.common.util.exception.ExceptionUtil;
 import org.checkerframework.checker.index.qual.NonNegative;
 
 /**
@@ -115,7 +115,7 @@ public abstract class AbstractDynamicBatchProcessor<Q, P extends BatchProcessor<
                 future.get();
             }
         } catch (ExecutionException e) {
-            Throwables.throwIfUnchecked(e.getCause());
+            ExceptionUtil.throwIfUnchecked(e.getCause());
             throw new AssertionError("Runnables must not throw checked exceptions", e);
         } catch (InterruptedException e) {
             Thread.interrupted();

--- a/oracles/parallelism/src/main/java/de/learnlib/oracle/parallelism/AbstractDynamicBatchProcessorBuilder.java
+++ b/oracles/parallelism/src/main/java/de/learnlib/oracle/parallelism/AbstractDynamicBatchProcessorBuilder.java
@@ -21,7 +21,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
-import com.google.common.base.Preconditions;
 import de.learnlib.oracle.BatchProcessor;
 import de.learnlib.oracle.ThreadPool.PoolPolicy;
 import net.automatalib.common.util.concurrent.ScalingThreadPoolExecutor;
@@ -55,7 +54,9 @@ public abstract class AbstractDynamicBatchProcessorBuilder<Q, P extends BatchPro
     }
 
     public AbstractDynamicBatchProcessorBuilder(Collection<? extends P> oracles) {
-        Preconditions.checkArgument(!oracles.isEmpty(), "No oracles specified");
+        if (oracles.isEmpty()) {
+            throw new IllegalArgumentException("No oracles specified");
+        }
         this.oracles = oracles;
         this.oracleSupplier = null;
     }

--- a/oracles/parallelism/src/main/java/de/learnlib/oracle/parallelism/AbstractStaticBatchProcessor.java
+++ b/oracles/parallelism/src/main/java/de/learnlib/oracle/parallelism/AbstractStaticBatchProcessor.java
@@ -24,13 +24,13 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import com.google.common.base.Throwables;
 import de.learnlib.exception.BatchInterruptedException;
 import de.learnlib.oracle.BatchProcessor;
 import de.learnlib.oracle.ThreadPool;
 import de.learnlib.setting.LearnLibProperty;
 import de.learnlib.setting.LearnLibSettings;
-import net.automatalib.common.smartcollection.ArrayStorage;
+import net.automatalib.common.util.array.ArrayStorage;
+import net.automatalib.common.util.exception.ExceptionUtil;
 import org.checkerframework.checker.index.qual.NonNegative;
 
 /**
@@ -144,9 +144,9 @@ public abstract class AbstractStaticBatchProcessor<Q, P extends BatchProcessor<Q
             for (Future<?> f : futures) {
                 f.get();
             }
-        } catch (ExecutionException ex) {
-            Throwables.throwIfUnchecked(ex.getCause());
-            throw new AssertionError("Runnable must not throw checked exceptions", ex);
+        } catch (ExecutionException e) {
+            ExceptionUtil.throwIfUnchecked(e.getCause());
+            throw new AssertionError("Runnable must not throw checked exceptions", e);
         } catch (InterruptedException ex) {
             Thread.interrupted();
             throw new BatchInterruptedException(ex);

--- a/oracles/parallelism/src/main/java/de/learnlib/oracle/parallelism/AbstractStaticBatchProcessorBuilder.java
+++ b/oracles/parallelism/src/main/java/de/learnlib/oracle/parallelism/AbstractStaticBatchProcessorBuilder.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Supplier;
 
-import com.google.common.base.Preconditions;
 import de.learnlib.oracle.BatchProcessor;
 import de.learnlib.oracle.ThreadPool.PoolPolicy;
 import org.checkerframework.checker.index.qual.NonNegative;
@@ -45,7 +44,9 @@ public abstract class AbstractStaticBatchProcessorBuilder<Q, P extends BatchProc
     private PoolPolicy poolPolicy = AbstractStaticBatchProcessor.POOL_POLICY;
 
     public AbstractStaticBatchProcessorBuilder(Collection<? extends P> oracles) {
-        Preconditions.checkArgument(!oracles.isEmpty(), "No oracles specified");
+        if (oracles.isEmpty()) {
+            throw new IllegalArgumentException("No oracles specified");
+        }
         this.oracles = oracles;
         this.oracleSupplier = null;
     }

--- a/oracles/parallelism/src/main/java/de/learnlib/oracle/parallelism/ParallelOracleBuilders.java
+++ b/oracles/parallelism/src/main/java/de/learnlib/oracle/parallelism/ParallelOracleBuilders.java
@@ -27,7 +27,7 @@ import de.learnlib.oracle.membership.StateLocalInputSULOracle;
 import de.learnlib.sul.ObservableSUL;
 import de.learnlib.sul.SUL;
 import de.learnlib.sul.StateLocalInputSUL;
-import net.automatalib.common.util.collection.CollectionsUtil;
+import net.automatalib.common.util.collection.CollectionUtil;
 import net.automatalib.word.Word;
 
 /**
@@ -143,7 +143,7 @@ public final class ParallelOracleBuilders {
     @SafeVarargs
     public static <I, D> DynamicParallelOracleBuilder<I, D> newDynamicParallelOracle(MembershipOracle<I, D> firstOracle,
                                                                                      MembershipOracle<I, D>... otherOracles) {
-        return newDynamicParallelOracle(CollectionsUtil.list(firstOracle, otherOracles));
+        return newDynamicParallelOracle(CollectionUtil.list(firstOracle, otherOracles));
     }
 
     /**
@@ -221,7 +221,7 @@ public final class ParallelOracleBuilders {
     public static <S, I, D> DynamicParallelOmegaOracleBuilder<S, I, D> newDynamicParallelOmegaOracle(
             OmegaMembershipOracle<S, I, D> firstOracle,
             OmegaMembershipOracle<S, I, D>... otherOracles) {
-        return newDynamicParallelOmegaOracle(CollectionsUtil.list(firstOracle, otherOracles));
+        return newDynamicParallelOmegaOracle(CollectionUtil.list(firstOracle, otherOracles));
     }
 
     /**
@@ -320,7 +320,7 @@ public final class ParallelOracleBuilders {
     @SafeVarargs
     public static <I, D> StaticParallelOracleBuilder<I, D> newStaticParallelOracle(MembershipOracle<I, D> firstOracle,
                                                                                    MembershipOracle<I, D>... otherOracles) {
-        return newStaticParallelOracle(CollectionsUtil.list(firstOracle, otherOracles));
+        return newStaticParallelOracle(CollectionUtil.list(firstOracle, otherOracles));
     }
 
     /**
@@ -397,7 +397,7 @@ public final class ParallelOracleBuilders {
     @SafeVarargs
     public static <S, I, D> StaticParallelOmegaOracleBuilder<S, I, D> newStaticParallelOmegaOracle(OmegaMembershipOracle<S, I, D> firstOracle,
                                                                                                    OmegaMembershipOracle<S, I, D>... otherOracles) {
-        return newStaticParallelOmegaOracle(CollectionsUtil.list(firstOracle, otherOracles));
+        return newStaticParallelOmegaOracle(CollectionUtil.list(firstOracle, otherOracles));
     }
 
     /**

--- a/oracles/parallelism/src/main/java/de/learnlib/oracle/parallelism/ParallelOracleBuilders.java
+++ b/oracles/parallelism/src/main/java/de/learnlib/oracle/parallelism/ParallelOracleBuilders.java
@@ -18,8 +18,6 @@ package de.learnlib.oracle.parallelism;
 import java.util.Collection;
 import java.util.function.Supplier;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import de.learnlib.oracle.MembershipOracle;
 import de.learnlib.oracle.OmegaMembershipOracle;
 import de.learnlib.oracle.ThreadPool.PoolPolicy;
@@ -29,6 +27,7 @@ import de.learnlib.oracle.membership.StateLocalInputSULOracle;
 import de.learnlib.sul.ObservableSUL;
 import de.learnlib.sul.SUL;
 import de.learnlib.sul.StateLocalInputSUL;
+import net.automatalib.common.util.collection.CollectionsUtil;
 import net.automatalib.word.Word;
 
 /**
@@ -67,8 +66,6 @@ import net.automatalib.word.Word;
  */
 public final class ParallelOracleBuilders {
 
-    private static final String FORKABLE_SUL_ERR = "SUL must be forkable for parallel processing";
-
     private ParallelOracleBuilders() {
         // prevent instantiation
     }
@@ -87,7 +84,7 @@ public final class ParallelOracleBuilders {
      * @return a preconfigured oracle builder
      */
     public static <I, O> DynamicParallelOracleBuilder<I, Word<O>> newDynamicParallelOracle(SUL<I, O> sul) {
-        Preconditions.checkArgument(sul.canFork(), FORKABLE_SUL_ERR);
+        checkFork(sul);
         return new DynamicParallelOracleBuilder<>(toSupplier(sul));
     }
 
@@ -109,7 +106,7 @@ public final class ParallelOracleBuilders {
      */
     public static <I, O> DynamicParallelOracleBuilder<I, Word<O>> newDynamicParallelOracle(StateLocalInputSUL<I, O> sul,
                                                                                            O undefinedInput) {
-        Preconditions.checkArgument(sul.canFork(), FORKABLE_SUL_ERR);
+        checkFork(sul);
         return new DynamicParallelOracleBuilder<>(toSupplier(sul, undefinedInput));
     }
 
@@ -146,7 +143,7 @@ public final class ParallelOracleBuilders {
     @SafeVarargs
     public static <I, D> DynamicParallelOracleBuilder<I, D> newDynamicParallelOracle(MembershipOracle<I, D> firstOracle,
                                                                                      MembershipOracle<I, D>... otherOracles) {
-        return newDynamicParallelOracle(Lists.asList(firstOracle, otherOracles));
+        return newDynamicParallelOracle(CollectionsUtil.list(firstOracle, otherOracles));
     }
 
     /**
@@ -181,7 +178,7 @@ public final class ParallelOracleBuilders {
      * @return a preconfigured oracle builder
      */
     public static <I, O> DynamicParallelOmegaOracleBuilder<?, I, Word<O>> newDynamicParallelOmegaOracle(ObservableSUL<?, I, O> sul) {
-        Preconditions.checkArgument(sul.canFork(), FORKABLE_SUL_ERR);
+        checkFork(sul);
         // instantiate inner supplier to resolve generics
         return new DynamicParallelOmegaOracleBuilder<>(toSupplier(sul)::get);
     }
@@ -224,7 +221,7 @@ public final class ParallelOracleBuilders {
     public static <S, I, D> DynamicParallelOmegaOracleBuilder<S, I, D> newDynamicParallelOmegaOracle(
             OmegaMembershipOracle<S, I, D> firstOracle,
             OmegaMembershipOracle<S, I, D>... otherOracles) {
-        return newDynamicParallelOmegaOracle(Lists.asList(firstOracle, otherOracles));
+        return newDynamicParallelOmegaOracle(CollectionsUtil.list(firstOracle, otherOracles));
     }
 
     /**
@@ -262,7 +259,7 @@ public final class ParallelOracleBuilders {
      * @return a preconfigured oracle builder
      */
     public static <I, O> StaticParallelOracleBuilder<I, Word<O>> newStaticParallelOracle(SUL<I, O> sul) {
-        Preconditions.checkArgument(sul.canFork(), FORKABLE_SUL_ERR);
+        checkFork(sul);
         return new StaticParallelOracleBuilder<>(toSupplier(sul));
     }
 
@@ -284,7 +281,7 @@ public final class ParallelOracleBuilders {
      */
     public static <I, O> StaticParallelOracleBuilder<I, Word<O>> newStaticParallelOracle(StateLocalInputSUL<I, O> sul,
                                                                                          O undefinedInput) {
-        Preconditions.checkArgument(sul.canFork(), FORKABLE_SUL_ERR);
+        checkFork(sul);
         return new StaticParallelOracleBuilder<>(toSupplier(sul, undefinedInput));
     }
 
@@ -323,7 +320,7 @@ public final class ParallelOracleBuilders {
     @SafeVarargs
     public static <I, D> StaticParallelOracleBuilder<I, D> newStaticParallelOracle(MembershipOracle<I, D> firstOracle,
                                                                                    MembershipOracle<I, D>... otherOracles) {
-        return newStaticParallelOracle(Lists.asList(firstOracle, otherOracles));
+        return newStaticParallelOracle(CollectionsUtil.list(firstOracle, otherOracles));
     }
 
     /**
@@ -358,7 +355,7 @@ public final class ParallelOracleBuilders {
      * @return a preconfigured oracle builder
      */
     public static <I, O> StaticParallelOmegaOracleBuilder<?, I, Word<O>> newStaticParallelOmegaOracle(ObservableSUL<?, I, O> sul) {
-        Preconditions.checkArgument(sul.canFork(), FORKABLE_SUL_ERR);
+        checkFork(sul);
         // instantiate inner supplier to resolve generics
         return new StaticParallelOmegaOracleBuilder<>(toSupplier(sul)::get);
     }
@@ -400,7 +397,7 @@ public final class ParallelOracleBuilders {
     @SafeVarargs
     public static <S, I, D> StaticParallelOmegaOracleBuilder<S, I, D> newStaticParallelOmegaOracle(OmegaMembershipOracle<S, I, D> firstOracle,
                                                                                                    OmegaMembershipOracle<S, I, D>... otherOracles) {
-        return newStaticParallelOmegaOracle(Lists.asList(firstOracle, otherOracles));
+        return newStaticParallelOmegaOracle(CollectionsUtil.list(firstOracle, otherOracles));
     }
 
     /**
@@ -435,5 +432,11 @@ public final class ParallelOracleBuilders {
 
     private static <S, I, O> Supplier<OmegaMembershipOracle<?, I, Word<O>>> toSupplier(ObservableSUL<S, I, O> sul) {
         return () -> AbstractSULOmegaOracle.newOracle(sul.fork());
+    }
+
+    private static <I, O> void checkFork(SUL<I, O> sul) {
+        if (!sul.canFork()) {
+            throw new IllegalArgumentException("SUL must be forkable for parallel processing");
+        }
     }
 }

--- a/oracles/parallelism/src/main/java/module-info.java
+++ b/oracles/parallelism/src/main/java/module-info.java
@@ -28,13 +28,11 @@
  */
 open module de.learnlib.oracle.parallelism {
 
-    requires com.google.common;
     requires de.learnlib.api;
     requires de.learnlib.oracle.membership;
     requires de.learnlib.setting;
     requires net.automatalib.api;
     requires net.automatalib.common.util;
-    requires net.automatalib.common.smartcollection;
     requires org.checkerframework.checker.qual;
 
     exports de.learnlib.oracle.parallelism;

--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,9 @@ limitations under the License.
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.release>8</maven.compiler.release>
+        <maven.compiler.testSource>11</maven.compiler.testSource>
+        <maven.compiler.testTarget>11</maven.compiler.testTarget>
+        <maven.compiler.testRelease>11</maven.compiler.testRelease>
         <argLine /> <!-- compatibility for property expansion in surefire-plugin -->
 
         <!-- plugin versions -->
@@ -238,7 +241,6 @@ limitations under the License.
         <cacio.version>1.11.1</cacio.version>
         <checkerframework.version>3.40.0</checkerframework.version>
         <checkstyle.version>9.3</checkstyle.version>
-        <guava.version>32.1.2-jre</guava.version>
         <javapoet.version>1.13.0</javapoet.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <logback.version>1.3.12</logback.version>
@@ -251,7 +253,6 @@ limitations under the License.
         <!-- Javadoc links -->
         <automatalib.apidocs>http://learnlib.github.io/automatalib/maven-site/${automatalib.version}/apidocs/</automatalib.apidocs>
         <checkerframework.apidocs>https://checkerframework.org/releases/${checkerframework.version}/api/</checkerframework.apidocs>
-        <guava.apidocs>http://google.github.io/guava/releases/${guava.version}/api/docs/</guava.apidocs>
     </properties>
 
     <!--
@@ -596,19 +597,6 @@ limitations under the License.
                 <scope>test</scope>
             </dependency>
 
-            <!-- Guava -->
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${guava.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.google.code.findbugs</groupId>
-                        <artifactId>jsr305</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
             <!-- Java Poet -->
             <dependency>
                 <groupId>com.squareup</groupId>
@@ -812,7 +800,6 @@ limitations under the License.
                         <detectLinks>true</detectLinks>
                         <linksource>false</linksource>
                         <links>
-                            <link>${guava.apidocs}</link>
                             <!-- TODO -->
                             <!-- JDK 17+ seems to fail on missing (SNAPSHOT) docs. reactivate before release -->
                             <!--link>${automatalib.apidocs}</link-->

--- a/test-support/test-support/pom.xml
+++ b/test-support/test-support/pom.xml
@@ -41,10 +41,6 @@
 
         <!-- external -->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
         </dependency>

--- a/test-support/test-support/src/main/java/de/learnlib/testsupport/AbstractVisualizationTest.java
+++ b/test-support/test-support/src/main/java/de/learnlib/testsupport/AbstractVisualizationTest.java
@@ -18,7 +18,6 @@ package de.learnlib.testsupport;
 import java.io.IOException;
 import java.io.InputStream;
 
-import com.google.common.io.CharStreams;
 import de.learnlib.algorithm.LearningAlgorithm;
 import de.learnlib.driver.simulator.MealySimulatorSUL;
 import de.learnlib.query.DefaultQuery;
@@ -66,7 +65,7 @@ public abstract class AbstractVisualizationTest<L extends LearningAlgorithm<? ex
     protected String resourceAsString(String resourceName) throws IOException {
         try (InputStream is = getClass().getResourceAsStream(resourceName)) {
             assert is != null;
-            return CharStreams.toString(IOUtil.asBufferedUTF8Reader(is));
+            return IOUtil.toString(IOUtil.asBufferedUTF8Reader(is));
         }
     }
 

--- a/test-support/test-support/src/main/java/module-info.java
+++ b/test-support/test-support/src/main/java/module-info.java
@@ -30,7 +30,6 @@
  */
 open module de.learnlib.testsupport {
 
-    requires com.google.common;
     requires de.learnlib.api;
     requires de.learnlib.common.util;
     requires de.learnlib.driver.simulator;


### PR DESCRIPTION
This PR removes the dependency on guava in order to progress towards `jlink` / `jpackage` support for LearnLib. Code which previously used guava's functionality has been refactored to use the new alternatives provided by AutomataLib.