### PR TITLE
Cleanup reported javadoc warnings

### DIFF
--- a/algorithms/active/adt/src/main/java/de/learnlib/algorithm/adt/adt/ADT.java
+++ b/algorithms/active/adt/src/main/java/de/learnlib/algorithm/adt/adt/ADT.java
@@ -96,6 +96,8 @@ public class ADT<S, I, O> {
     /**
      * Successively sifts a word through the ADT induced by the given node. Stops when reaching a leaf.
      *
+     * @param oracle
+     *         the oracle to query with inner node symbols
      * @param word
      *         the word to sift
      * @param subtree

--- a/algorithms/active/kearns-vazirani/src/main/java/de/learnlib/algorithm/kv/dfa/KearnsVaziraniDFA.java
+++ b/algorithms/active/kearns-vazirani/src/main/java/de/learnlib/algorithm/kv/dfa/KearnsVaziraniDFA.java
@@ -72,6 +72,10 @@ public class KearnsVaziraniDFA<I>
      *         the learning alphabet
      * @param oracle
      *         the membership oracle
+     * @param repeatedCounterexampleEvaluation
+     *         a flag whether counterexamples should be analyzed exhaustively
+     * @param counterexampleAnalyzer
+     *         the counterexample analyzer
      */
     @GenerateBuilder(defaults = BuilderDefaults.class)
     public KearnsVaziraniDFA(Alphabet<I> alphabet,

--- a/algorithms/active/lstar/src/main/java/de/learnlib/algorithm/lstar/AbstractAutomatonLStar.java
+++ b/algorithms/active/lstar/src/main/java/de/learnlib/algorithm/lstar/AbstractAutomatonLStar.java
@@ -63,6 +63,8 @@ public abstract class AbstractAutomatonLStar<A, I, D, S, T, SP, TP, AI extends M
      *         the learning alphabet
      * @param oracle
      *         the learning oracle
+     * @param internalHyp
+     *         the internal hypothesis object to write data to
      */
     protected AbstractAutomatonLStar(Alphabet<I> alphabet, MembershipOracle<I, D> oracle, AI internalHyp) {
         super(alphabet, oracle);
@@ -159,9 +161,11 @@ public abstract class AbstractAutomatonLStar<A, I, D, S, T, SP, TP, AI extends M
     /**
      * Derives a transition property from the corresponding transition.
      * <p>
-     * N.B.: Not the transition row is passed to this method, but the row for the outgoing state. The transition row can
-     * be retrieved using {@link Row#getSuccessor(int)}.
+     * Note that not the transition row is passed to this method, but the row for the outgoing state. The transition row
+     * can be retrieved using {@link Row#getSuccessor(int)}.
      *
+     * @param table
+     *         the observation table
      * @param stateRow
      *         the row for the source state
      * @param inputIdx

--- a/algorithms/active/lstar/src/main/java/de/learnlib/algorithm/lstar/AbstractLStar.java
+++ b/algorithms/active/lstar/src/main/java/de/learnlib/algorithm/lstar/AbstractLStar.java
@@ -122,11 +122,16 @@ public abstract class AbstractLStar<A, I, D>
     protected abstract List<Word<I>> initialSuffixes();
 
     /**
-     * Iteratedly checks for unclosedness and inconsistencies in the table, and fixes any occurrences thereof. This
+     * Iteratively checks for unclosedness and inconsistencies in the table, and fixes any occurrences thereof. This
      * process is repeated until the observation table is both closed and consistent.
      *
      * @param unclosed
      *         the unclosed rows (equivalence classes) to start with.
+     * @param checkConsistency
+     *         a flag indicating whether consistency should be checked as well. If {@code false}, only closedness is
+     *         ensured.
+     *
+     * @return {@code true} if unclosed rows have been closed, {@code false} otherwise
      */
     protected boolean completeConsistentTable(List<List<Row<I>>> unclosed, boolean checkConsistency) {
         boolean refined = false;

--- a/algorithms/active/lstar/src/main/java/de/learnlib/algorithm/lstar/closing/ClosingStrategy.java
+++ b/algorithms/active/lstar/src/main/java/de/learnlib/algorithm/lstar/closing/ClosingStrategy.java
@@ -44,6 +44,10 @@ public interface ClosingStrategy<I, D> {
      *         the observation table
      * @param oracle
      *         the membership oracle
+     * @param <RI>
+     *         the (concrete) row input type
+     * @param <RO>
+     *         the (concrete) row output type
      *
      * @return a selection of representative rows to be closed.
      */

--- a/algorithms/active/lstar/src/main/java/de/learnlib/algorithm/lstar/dfa/ExtensibleLStarDFA.java
+++ b/algorithms/active/lstar/src/main/java/de/learnlib/algorithm/lstar/dfa/ExtensibleLStarDFA.java
@@ -38,7 +38,7 @@ import net.automatalib.word.Word;
  * Queries and Counterexamples".
  *
  * @param <I>
- *         input symbol class.
+ *         input symbol type
  */
 public class ExtensibleLStarDFA<I>
         extends AbstractExtensibleAutomatonLStar<DFA<?, I>, I, Boolean, Integer, Integer, Boolean, Void, CompactDFA<I>>
@@ -48,9 +48,15 @@ public class ExtensibleLStarDFA<I>
      * Constructor.
      *
      * @param alphabet
-     *         the learning alphabet.
+     *         the learning alphabet
      * @param oracle
-     *         the DFA oracle.
+     *         the DFA oracle
+     * @param initialSuffixes
+     *         the list of initial suffixes used in the observation table
+     * @param cexHandler
+     *         the strategy for handling counterexamples
+     * @param closingStrategy
+     *         the strategy for closing open rows of the observation table
      */
     public ExtensibleLStarDFA(Alphabet<I> alphabet,
                               MembershipOracle<I, Boolean> oracle,

--- a/algorithms/active/observation-pack/src/main/java/de/learnlib/algorithm/observationpack/dfa/OPLearnerDFA.java
+++ b/algorithms/active/observation-pack/src/main/java/de/learnlib/algorithm/observationpack/dfa/OPLearnerDFA.java
@@ -48,6 +48,8 @@ public class OPLearnerDFA<I> extends AbstractOPLearner<DFA<?, I>, I, Boolean, Bo
      *         the membership oracle
      * @param suffixFinder
      *         method to use for analyzing counterexamples
+     * @param repeatedCounterexampleEvaluation
+     *         a flag whether counterexamples should be analyzed exhaustively
      * @param epsilonRoot
      *         whether to ensure the root of the discrimination tree is always labeled using the empty word.
      */

--- a/algorithms/active/observation-pack/src/main/java/de/learnlib/algorithm/observationpack/hypothesis/HState.java
+++ b/algorithms/active/observation-pack/src/main/java/de/learnlib/algorithm/observationpack/hypothesis/HState.java
@@ -114,9 +114,6 @@ public class HState<I, O, SP, TP> {
         nonTreeIncoming.clear();
     }
 
-    /**
-     * See {@link ResizingArrayStorage#ensureCapacity(int)}.
-     */
     public boolean ensureInputCapacity(int capacity) {
         return this.transitions.ensureCapacity(capacity);
     }

--- a/algorithms/active/observation-pack/src/main/java/de/learnlib/algorithm/observationpack/mealy/OPLearnerMealy.java
+++ b/algorithms/active/observation-pack/src/main/java/de/learnlib/algorithm/observationpack/mealy/OPLearnerMealy.java
@@ -50,6 +50,8 @@ public class OPLearnerMealy<I, O> extends AbstractOPLearner<MealyMachine<?, I, ?
      *         the membership oracle
      * @param suffixFinder
      *         method to use for analyzing counterexamples
+     * @param repeatedCounterexampleEvaluation
+     *         a flag whether counterexamples should be analyzed exhaustively
      */
     @GenerateBuilder(defaults = AbstractOPLearner.BuilderDefaults.class)
     public OPLearnerMealy(Alphabet<I> alphabet,

--- a/algorithms/active/ttt/src/main/java/de/learnlib/algorithm/ttt/base/AbstractTTTLearner.java
+++ b/algorithms/active/ttt/src/main/java/de/learnlib/algorithm/ttt/base/AbstractTTTLearner.java
@@ -51,8 +51,12 @@ import org.slf4j.LoggerFactory;
 /**
  * The TTT learning algorithm for generic automata.
  *
+ * @param <A>
+ *         hypothesis automaton type
  * @param <I>
  *         input symbol type
+ * @param <D>
+ *         output domain type
  */
 @SuppressWarnings("PMD.ExcessiveClassLength")
 public abstract class AbstractTTTLearner<A, I, D>
@@ -116,6 +120,10 @@ public abstract class AbstractTTTLearner<A, I, D>
      *         the old node
      * @param label
      *         the label to consider
+     * @param <I>
+     *         input symbol type
+     * @param <D>
+     *         output domain type
      */
     private static <I, D> void moveIncoming(AbstractBaseDTNode<I, D> newNode,
                                             AbstractBaseDTNode<I, D> oldNode,
@@ -130,6 +138,10 @@ public abstract class AbstractTTTLearner<A, I, D>
      *         the node in the discrimination tree
      * @param state
      *         the state in the hypothesis
+     * @param <I>
+     *         input symbol type
+     * @param <D>
+     *         output domain type
      */
     protected static <I, D> void link(AbstractBaseDTNode<I, D> dtNode, TTTState<I, D> state) {
         assert dtNode.isLeaf();

--- a/algorithms/active/ttt/src/main/java/de/learnlib/algorithm/ttt/base/TTTState.java
+++ b/algorithms/active/ttt/src/main/java/de/learnlib/algorithm/ttt/base/TTTState.java
@@ -87,9 +87,6 @@ public class TTTState<I, D> implements AccessSequenceProvider<I> {
         return transitions.array;
     }
 
-    /**
-     * See {@link ResizingArrayStorage#ensureCapacity(int)}.
-     */
     public boolean ensureInputCapacity(int capacity) {
         return this.transitions.ensureCapacity(capacity);
     }

--- a/api/src/main/java/de/learnlib/oracle/PropertyOracle.java
+++ b/api/src/main/java/de/learnlib/oracle/PropertyOracle.java
@@ -56,7 +56,8 @@ public interface PropertyOracle<I, A extends Output<I, D>, P, D> extends Inclusi
     /**
      * Set the property.
      *
-     * @param property the property to set.
+     * @param property
+     *         the property to set
      */
     void setProperty(P property);
 
@@ -65,13 +66,14 @@ public interface PropertyOracle<I, A extends Output<I, D>, P, D> extends Inclusi
      *
      * @return the property.
      */
-    @Pure P getProperty();
+    @Pure
+    P getProperty();
 
     /**
      * Returns the counterexample for the property if {@link #isDisproved()}, {@code null} otherwise.
      * <p>
-     * If this method does not return {@code null}, a previous call to {@link #disprove(Output, Collection)} must
-     * have returned a {@link DefaultQuery}.
+     * If this method does not return {@code null}, a previous call to {@link #disprove(Output, Collection)} must have
+     * returned a {@link DefaultQuery}.
      *
      * @return the counterexample for the property if {@link #isDisproved()}, {@code null} otherwise.
      */
@@ -80,22 +82,26 @@ public interface PropertyOracle<I, A extends Output<I, D>, P, D> extends Inclusi
     /**
      * Try to disprove the property with the given {@code hypothesis}.
      *
-     * @param hypothesis the hypothesis.
-     * @param inputs the inputs
+     * @param hypothesis
+     *         the hypothesis
+     * @param inputs
+     *         the inputs
      *
-     * @return the {@link DefaultQuery} that is a counterexample the property, or {@code null}, if the property
-     * could not be disproved.
+     * @return the {@link DefaultQuery} that is a counterexample the property, or {@code null}, if the property could
+     * not be disproved.
      */
     @Nullable DefaultQuery<I, D> disprove(A hypothesis, Collection<? extends I> inputs);
 
     /**
      * Try to find a counterexample to the given {@code hypothesis} if the property can not be disproved.
      *
-     * @param hypothesis the hypothesis to find a counterexample to.
-     * @param inputs the input alphabet.
+     * @param hypothesis
+     *         the hypothesis to find a counterexample to
+     * @param inputs
+     *         the input symbols to consider for finding a counterexample
      *
-     * @return the {@link DefaultQuery} that is a counterexample to the given {@code hypothesis}, or {@code
-     * null}, a counterexample could not be found or the property could be disproved.
+     * @return the {@link DefaultQuery} that is a counterexample to the given {@code hypothesis}, or {@code null}, a
+     * counterexample could not be found or the property could be disproved.
      */
     @Override
     default @Nullable DefaultQuery<I, D> findCounterExample(A hypothesis, Collection<? extends I> inputs) {
@@ -103,8 +109,15 @@ public interface PropertyOracle<I, A extends Output<I, D>, P, D> extends Inclusi
     }
 
     /**
-     * Unconditionally find a counterexample, i.e. regardless of whether the property can be disproved. In fact,
+     * Unconditionally find a counterexample, i.e., regardless of whether the property can be disproved. In fact,
      * {@link #disprove(Output, Collection)} is not even be called.
+     *
+     * @param hypothesis
+     *         the hypothesis to find a counterexample to
+     * @param inputs
+     *         the input symbols to consider for finding a counterexample
+     *
+     * @return a counterexample for the current hypothesis. May be {@code null} of none can be found
      *
      * @see #findCounterExample(Output, Collection)
      */

--- a/api/src/main/java/de/learnlib/query/AbstractQuery.java
+++ b/api/src/main/java/de/learnlib/query/AbstractQuery.java
@@ -49,6 +49,9 @@ public abstract class AbstractQuery<I, D> extends Query<I, D> {
      * Returns the string representation of this query, including a possible answer. This method should be used by
      * classes extending {@link AbstractQuery} for their toString method to ensure output consistency.
      *
+     * @param answer
+     *         the output object to render as answer
+     *
      * @return A string of the form {@code "Query[<prefix>|<suffix> / <answer>]"}. If the query has not been answered
      * yet, {@code <answer>} will be null.
      */

--- a/commons/counterexamples/src/main/java/de/learnlib/acex/AcexAnalysisAlgorithms.java
+++ b/commons/counterexamples/src/main/java/de/learnlib/acex/AcexAnalysisAlgorithms.java
@@ -30,6 +30,8 @@ public final class AcexAnalysisAlgorithms {
      *         the lower bound of the search range
      * @param high
      *         the upper bound of the search range
+     * @param <E>
+     *         the effect type
      *
      * @return an index <code>i</code> such that <code>acex.testEffect(i) != acex.testEffect(i+1)</code>
      */
@@ -56,6 +58,8 @@ public final class AcexAnalysisAlgorithms {
      *         the lower bound of the search range
      * @param high
      *         the upper bound of the search range
+     * @param <E>
+     *         the effect type
      *
      * @return an index <code>i</code> such that <code>acex.testEffect(i) != acex.testEffect(i+1)</code>
      */
@@ -82,6 +86,8 @@ public final class AcexAnalysisAlgorithms {
      *         the lower bound of the search range
      * @param high
      *         the upper bound of the search range
+     * @param <E>
+     *         the effect type
      *
      * @return an index <code>i</code> such that <code>acex.testEffect(i) != acex.testEffect(i+1)</code>
      */
@@ -117,6 +123,8 @@ public final class AcexAnalysisAlgorithms {
      *         the lower bound of the search range
      * @param high
      *         the upper bound of the search range
+     * @param <E>
+     *         the effect type
      *
      * @return an index <code>i</code> such that <code>acex.testEffect(i) != acex.testEffect(i+1)</code>
      */

--- a/commons/counterexamples/src/main/java/de/learnlib/counterexample/AcexLocalSuffixFinder.java
+++ b/commons/counterexamples/src/main/java/de/learnlib/counterexample/AcexLocalSuffixFinder.java
@@ -43,6 +43,8 @@ public class AcexLocalSuffixFinder implements LocalSuffixFinder<@Nullable Object
      *         the analyzer to be wrapped
      * @param reduce
      *         whether to reduce counterexamples
+     * @param name
+     *         the display name of the suffix finder
      */
     public AcexLocalSuffixFinder(AcexAnalyzer analyzer, boolean reduce, String name) {
         this.analyzer = analyzer;

--- a/commons/counterexamples/src/main/java/de/learnlib/counterexample/GlobalSuffixFinders.java
+++ b/commons/counterexamples/src/main/java/de/learnlib/counterexample/GlobalSuffixFinders.java
@@ -133,6 +133,15 @@ public final class GlobalSuffixFinders {
      * Transforms a {@link LocalSuffixFinder} into a global one. This is a convenience method, behaving like {@link
      * #fromLocalFinder(LocalSuffixFinder, boolean)}.
      *
+     * @param localFinder
+     *         the local finder to transform
+     * @param <I>
+     *         input symbol type
+     * @param <D>
+     *         output domain type
+     *
+     * @return the transformed global suffix finder
+     *
      * @see #fromLocalFinder(LocalSuffixFinder, boolean)
      */
     public static <I, D> GlobalSuffixFinder<I, D> fromLocalFinder(LocalSuffixFinder<I, D> localFinder) {
@@ -153,6 +162,10 @@ public final class GlobalSuffixFinders {
      *         the local suffix finder
      * @param allSuffixes
      *         whether all suffixes of the found local suffix should be added
+     * @param <I>
+     *         input symbol type
+     * @param <D>
+     *         output domain type
      *
      * @return a global suffix finder using the analysis method from the specified local suffix finder
      */
@@ -180,6 +193,17 @@ public final class GlobalSuffixFinders {
     /**
      * Transforms a suffix index returned by a {@link LocalSuffixFinder} into a list containing the single
      * distinguishing suffix.
+     *
+     * @param ceQuery
+     *         the counterexample
+     * @param localSuffixIdx
+     *         the (local) suffix index
+     * @param <I>
+     *         input symbol type
+     * @param <D>
+     *         output domain type
+     *
+     * @return the (singleton) list of the distinguishing suffix
      */
     public static <I, D> List<Word<I>> suffixesForLocalOutput(Query<I, D> ceQuery, int localSuffixIdx) {
         return suffixesForLocalOutput(ceQuery, localSuffixIdx, false);
@@ -188,13 +212,29 @@ public final class GlobalSuffixFinders {
     /**
      * Transforms a suffix index returned by a {@link LocalSuffixFinder} into a list of distinguishing suffixes. This
      * list always contains the corresponding local suffix. Since local suffix finders only return a single suffix,
-     * suffix-closedness of the set of distinguishing suffixes might not be preserved. Note that for correctly
-     * implemented local suffix finders, this does not impair correctness of the learning algorithm. However, without
-     * suffix closedness, intermediate hypothesis models might be non-canonical, if no additional precautions are taken.
-     * For that reasons, the {@code allSuffixes} parameter can be specified to control whether the list returned by
+     * suffix-closedness of the set of distinguishing suffixes might not be preserved.
+     * <p>
+     * Note that for correctly implemented local suffix finders, this does not impair correctness of the learning
+     * algorithm. However, without suffix closedness, intermediate hypothesis models might be non-canonical, if no
+     * additional precautions are taken. For that reasons, the {@code allSuffixes} parameter can be specified to control
+     * whether the list returned by
      * {@link GlobalSuffixFinder#findSuffixes(Query, AccessSequenceTransformer, SuffixOutput, MembershipOracle)} of the
      * returned global suffix finder should not only contain the single suffix, but also all of its suffixes, ensuring
      * suffix-closedness.
+     *
+     * @param ceQuery
+     *         the counterexample
+     * @param localSuffixIdx
+     *         the (local) suffix index
+     * @param allSuffixes
+     *         a flag indicating whether all suffixes of the distinguishing suffix should be included in the returned
+     *         list
+     * @param <I>
+     *         input symbol type
+     * @param <D>
+     *         output domain type
+     *
+     * @return the list of distinguishing suffixes
      */
     public static <I, D> List<Word<I>> suffixesForLocalOutput(Query<I, D> ceQuery,
                                                               int localSuffixIdx,
@@ -218,6 +258,10 @@ public final class GlobalSuffixFinders {
      *
      * @param ceQuery
      *         the counterexample query
+     * @param <I>
+     *         input symbol type
+     * @param <D>
+     *         output domain type
      *
      * @return all suffixes of the counterexample input
      */
@@ -233,6 +277,10 @@ public final class GlobalSuffixFinders {
      *         the counterexample query
      * @param asTransformer
      *         the access sequence transformer
+     * @param <I>
+     *         input symbol type
+     * @param <D>
+     *         output domain type
      *
      * @return all suffixes from the counterexample after stripping a maximal one-letter extension of an access
      * sequence.
@@ -270,6 +318,10 @@ public final class GlobalSuffixFinders {
      *         interface to the SUL output
      * @param allSuffixes
      *         whether to include all suffixes of the found suffix
+     * @param <I>
+     *         input symbol type
+     * @param <D>
+     *         output domain type
      *
      * @return the distinguishing suffixes
      *
@@ -298,6 +350,10 @@ public final class GlobalSuffixFinders {
      *         interface to the SUL output
      * @param allSuffixes
      *         whether to include all suffixes of the found suffix
+     * @param <I>
+     *         input symbol type
+     * @param <D>
+     *         output domain type
      *
      * @return the distinguishing suffixes
      *
@@ -326,15 +382,19 @@ public final class GlobalSuffixFinders {
      *         interface to the SUL output
      * @param allSuffixes
      *         whether to include all suffixes of the found suffix
+     * @param <I>
+     *         input symbol type
+     * @param <D>
+     *         output domain type
      *
      * @return the distinguishing suffixes
      *
      * @see LocalSuffixFinders#findRivestSchapire(Query, AccessSequenceTransformer, SuffixOutput, MembershipOracle)
      */
-    public static <I, O> List<Word<I>> findRivestSchapire(Query<I, O> ceQuery,
+    public static <I, D> List<Word<I>> findRivestSchapire(Query<I, D> ceQuery,
                                                           AccessSequenceTransformer<I> asTransformer,
-                                                          SuffixOutput<I, O> hypOutput,
-                                                          MembershipOracle<I, O> oracle,
+                                                          SuffixOutput<I, D> hypOutput,
+                                                          MembershipOracle<I, D> oracle,
                                                           boolean allSuffixes) {
         int idx = LocalSuffixFinders.findRivestSchapire(ceQuery, asTransformer, hypOutput, oracle);
         return suffixesForLocalOutput(ceQuery, idx, allSuffixes);

--- a/commons/counterexamples/src/main/java/de/learnlib/counterexample/LocalSuffixFinders.java
+++ b/commons/counterexamples/src/main/java/de/learnlib/counterexample/LocalSuffixFinders.java
@@ -72,6 +72,10 @@ public final class LocalSuffixFinders {
      *         interface to the hypothesis output, for checking whether the oracle output contradicts the hypothesis
      * @param oracle
      *         interface to the SUL
+     * @param <I>
+     *         input symbol type
+     * @param <D>
+     *         output domain type
      *
      * @return the index of the respective suffix, or {@code -1} if no counterexample could be found
      *
@@ -102,6 +106,10 @@ public final class LocalSuffixFinders {
      *         interface to the hypothesis output, for checking whether the oracle output contradicts the hypothesis
      * @param oracle
      *         interface to the SUL
+     * @param <I>
+     *         input symbol type
+     * @param <D>
+     *         output domain type
      *
      * @return the index of the respective suffix, or {@code -1} if no counterexample could be found
      *
@@ -132,6 +140,10 @@ public final class LocalSuffixFinders {
      *         interface to the hypothesis output, for checking whether the oracle output contradicts the hypothesis
      * @param oracle
      *         interface to the SUL
+     * @param <I>
+     *         input symbol type
+     * @param <D>
+     *         output domain type
      *
      * @return the index of the respective suffix, or {@code -1} if no counterexample could be found
      *

--- a/datastructures/discrimination-tree/src/main/java/de/learnlib/datastructure/discriminationtree/iterators/DiscriminationTreeIterators.java
+++ b/datastructures/discrimination-tree/src/main/java/de/learnlib/datastructure/discriminationtree/iterators/DiscriminationTreeIterators.java
@@ -31,24 +31,28 @@ public final class DiscriminationTreeIterators {
     }
 
     /**
-     * Iterator that traverses all nodes of a subtree of a given discrimination tree node.
+     * Returns an iterator that traverses all nodes of a subtree of a given discrimination tree node.
      *
      * @param root
      *         the root node, from which traversal should start
      * @param <N>
      *         node type
+     *
+     * @return an iterator that traverses all nodes of a subtree of the given node
      */
     public static <N extends AbstractDTNode<?, ?, ?, N>> Iterator<N> nodeIterator(N root) {
         return new NodeIterator<>(root);
     }
 
     /**
-     * Iterator that traverses all inner nodes (no leaves) of a subtree of a given discrimination tree node.
+     * Returns an iterator that traverses all inner nodes (no leaves) of a subtree of a given discrimination tree node.
      *
      * @param root
      *         the root node, from which traversal should start
      * @param <N>
      *         node type
+     *
+     * @return an iterator that traverses all inner nodes of a subtree of the given node
      */
     @SuppressWarnings("nullness") // lambda is only called with our non-null nodes as argument
     public static <N extends AbstractDTNode<?, ?, ?, N>> Iterator<N> innerNodeIterator(N root) {
@@ -56,20 +60,22 @@ public final class DiscriminationTreeIterators {
     }
 
     /**
-     * Iterator that traverses all leaves (no inner nodes) of a subtree of a given discrimination tree node.
+     * Returns an iterator that traverses all leaves (no inner nodes) of a subtree of a given discrimination tree node.
      *
      * @param root
      *         the root node, from which traversal should start
      * @param <N>
      *         node type
+     *
+     * @return an iterator that traverses all leaf nodes of a subtree of the given node
      */
     public static <N extends AbstractDTNode<?, ?, ?, N>> Iterator<N> leafIterator(N root) {
         return IteratorUtil.filter(nodeIterator(root), AbstractDTNode::isLeaf);
     }
 
     /**
-     * Iterator that traverses all leaves (no inner nodes) of a subtree of a given discrimination tree node.
-     * Additionally, allows to specify a transformer that is applied to the leaf nodes
+     * Returns an iterator that traverses all leaves (no inner nodes) of a subtree of a given discrimination tree node.
+     * Additionally, allows one to specify a transformer that is applied to the leaf nodes
      *
      * @param root
      *         the root node, from which traversal should start
@@ -77,6 +83,10 @@ public final class DiscriminationTreeIterators {
      *         the transformer that transforms iterated nodes
      * @param <N>
      *         node type
+     * @param <D>
+     *         transformation target data type
+     *
+     * @return an iterator that traverses all (transformed) leaf nodes of a subtree of the given node
      */
     public static <N extends AbstractDTNode<?, ?, ?, N>, D> Iterator<D> transformingLeafIterator(N root,
                                                                                                  Function<? super N, D> transformer) {

--- a/datastructures/observation-table/src/main/java/de/learnlib/datastructure/observationtable/MutableObservationTable.java
+++ b/datastructures/observation-table/src/main/java/de/learnlib/datastructure/observationtable/MutableObservationTable.java
@@ -27,8 +27,10 @@ public interface MutableObservationTable<I, D> extends ObservationTable<I, D> {
     /**
      * Initializes an observation table using a specified set of suffixes.
      *
+     * @param initialShortPrefixes
+     *         the set of initial row labels
      * @param initialSuffixes
-     *         the set of initial column labels.
+     *         the set of initial column labels
      * @param oracle
      *         the {@link MembershipOracle} to use for performing queries
      *

--- a/datastructures/observation-table/src/main/java/de/learnlib/datastructure/observationtable/ObservationTable.java
+++ b/datastructures/observation-table/src/main/java/de/learnlib/datastructure/observationtable/ObservationTable.java
@@ -208,12 +208,15 @@ public interface ObservationTable<I, D> extends AccessSequenceTransformer<I> {
     }
 
     /**
+     * Returns a distinguishing suffix that distinguishes the two access sequences represented by the labels of the
+     * given rows.
+     *
      * @param row1
      *         the first row
      * @param row2
      *         the second row
      *
-     * @return the suffix distinguishing the contents of the two rows
+     * @return the suffix that distinguishes the two rows. {@code null} if no such suffix can be found.
      */
     default @Nullable Word<I> findDistinguishingSuffix(Row<I> row1, Row<I> row2) {
         int suffixIndex = findDistinguishingSuffixIndex(row1, row2);
@@ -224,8 +227,13 @@ public interface ObservationTable<I, D> extends AccessSequenceTransformer<I> {
     }
 
     /**
-     * @return the suffix (column) index where the contents of the rows differ, or {@code #NO_DISTINGUISHING_SUFFIX} if
-     * the contents of the rows are equal.
+     * Returns a suffix (column) index which uncovers an observation discrepancy described by a given inconsistency.
+     *
+     * @param inconsistency
+     *         the inconsistency
+     *
+     * @return the suffix (column) index which exhibits the observation discrepancy described by a given inconsistency,
+     * or {@link #NO_DISTINGUISHING_SUFFIX} if no such index can be found.
      */
     default @Signed int findDistinguishingSuffixIndex(Inconsistency<I> inconsistency) {
         Row<I> row1 = inconsistency.getFirstRow();
@@ -236,13 +244,16 @@ public interface ObservationTable<I, D> extends AccessSequenceTransformer<I> {
     }
 
     /**
+     * Returns a suffix (column) index which uncovers an observation discrepancy between the two access sequences
+     * represented by the labels of the given rows.
+     *
      * @param row1
      *         the first row
      * @param row2
      *         the second row
      *
-     * @return the suffix (column) index where the contents of the rows differ, or {@code #NO_DISTINGUISHING_SUFFIX} if
-     * the contents of the rows are equal.
+     * @return the suffix (column) index which exhibits an observation discrepancy between the two given rows, or
+     * {@link #NO_DISTINGUISHING_SUFFIX} if no such index can be found.
      */
     default @Signed int findDistinguishingSuffixIndex(Row<I> row1, Row<I> row2) {
         for (int i = 0; i < getSuffixes().size(); i++) {

--- a/datastructures/pta/src/main/java/de/learnlib/datastructure/pta/config/ProcessingOrder.java
+++ b/datastructures/pta/src/main/java/de/learnlib/datastructure/pta/config/ProcessingOrder.java
@@ -37,6 +37,9 @@ public interface ProcessingOrder {
     /**
      * Creates a worklist for managing the set of blue states in the RPNI algorithm.
      *
+     * @param <S>
+     *         the (concrete) state type
+     *
      * @return a worklist with some specific ordering constraints
      */
     <S extends AbstractBlueFringePTAState<S, ?, ?>> Queue<PTATransition<S>> createWorklist();

--- a/filters/cache/src/main/java/de/learnlib/filter/cache/dfa/DFACaches.java
+++ b/filters/cache/src/main/java/de/learnlib/filter/cache/dfa/DFACaches.java
@@ -44,6 +44,8 @@ public final class DFACaches {
      *         the input alphabet
      * @param mqOracle
      *         the membership oracle
+     * @param <I>
+     *         input symbol type
      *
      * @return a Mealy learning cache with a default implementation
      */
@@ -57,7 +59,7 @@ public final class DFACaches {
      * @param alphabet
      *         the alphabet containing the symbols of possible queries
      * @param mqOracle
-     *         the oracle to delegate queries to, in case of a cache-miss.
+     *         the oracle to delegate queries to, in case of a cache-miss
      * @param <I>
      *         input symbol type
      *
@@ -75,7 +77,7 @@ public final class DFACaches {
      * @param alphabet
      *         the alphabet containing the symbols of possible queries
      * @param mqOracle
-     *         the oracle to delegate queries to, in case of a cache-miss.
+     *         the oracle to delegate queries to, in case of a cache-miss
      * @param <I>
      *         input symbol type
      *
@@ -93,7 +95,7 @@ public final class DFACaches {
      * @param alphabet
      *         the alphabet containing the symbols of possible queries
      * @param mqOracle
-     *         the oracle to delegate queries to, in case of a cache-miss.
+     *         the oracle to delegate queries to, in case of a cache-miss
      * @param <I>
      *         input symbol type
      *
@@ -111,7 +113,7 @@ public final class DFACaches {
      * @param alphabet
      *         the alphabet containing the symbols of possible queries
      * @param mqOracle
-     *         the oracle to delegate queries to, in case of a cache-miss.
+     *         the oracle to delegate queries to, in case of a cache-miss
      * @param <I>
      *         input symbol type
      *
@@ -127,7 +129,7 @@ public final class DFACaches {
      * Creates a cache oracle for a DFA learning setup, using a {@link Map} for internal cache organization.
      *
      * @param mqOracle
-     *         the oracle to delegate queries to, in case of a cache-miss.
+     *         the oracle to delegate queries to, in case of a cache-miss
      * @param <I>
      *         input symbol type
      *

--- a/filters/cache/src/main/java/de/learnlib/filter/cache/mealy/MealyCaches.java
+++ b/filters/cache/src/main/java/de/learnlib/filter/cache/mealy/MealyCaches.java
@@ -43,6 +43,10 @@ public final class MealyCaches {
      *         the input alphabet
      * @param mqOracle
      *         the membership oracle
+     * @param <I>
+     *         input symbol type
+     * @param <O>
+     *         output symbol type
      *
      * @return a Mealy learning cache with a default implementation
      */
@@ -58,6 +62,10 @@ public final class MealyCaches {
      *         the input alphabet
      * @param mqOracle
      *         the membership oracle
+     * @param <I>
+     *         input symbol type
+     * @param <O>
+     *         output symbol type
      *
      * @return a Mealy learning cache with a DAG-based implementation
      *
@@ -77,6 +85,10 @@ public final class MealyCaches {
      *         a mapping for the prefix-closure filter
      * @param mqOracle
      *         the membership oracle
+     * @param <I>
+     *         input symbol type
+     * @param <O>
+     *         output symbol type
      *
      * @return a Mealy learning cache with a DAG-based implementation
      *
@@ -95,6 +107,10 @@ public final class MealyCaches {
      *         the input alphabet
      * @param mqOracle
      *         the membership oracle
+     * @param <I>
+     *         input symbol type
+     * @param <O>
+     *         output symbol type
      *
      * @return a Mealy learning cache with a tree-based implementation
      *
@@ -114,6 +130,10 @@ public final class MealyCaches {
      *         a mapping for the prefix-closure filter
      * @param mqOracle
      *         the membership oracle
+     * @param <I>
+     *         input symbol type
+     * @param <O>
+     *         output symbol type
      *
      * @return a Mealy learning cache with a tree-based implementation
      *
@@ -135,6 +155,10 @@ public final class MealyCaches {
      *
      * @param mqOracle
      *         the membership oracle
+     * @param <I>
+     *         input symbol type
+     * @param <O>
+     *         output symbol type
      *
      * @return a Mealy learning cache with a tree-based implementation
      *
@@ -156,6 +180,10 @@ public final class MealyCaches {
      *         a mapping for the prefix-closure filter
      * @param mqOracle
      *         the membership oracle
+     * @param <I>
+     *         input symbol type
+     * @param <O>
+     *         output symbol type
      *
      * @return a Mealy learning cache with a tree-based implementation
      *
@@ -174,6 +202,10 @@ public final class MealyCaches {
      *         the input alphabet
      * @param mqOracle
      *         the membership oracle
+     * @param <I>
+     *         input symbol type
+     * @param <O>
+     *         output symbol type
      *
      * @return a symbol-based Mealy learning cache with a tree-based implementation
      */

--- a/filters/cache/src/main/java/de/learnlib/filter/cache/moore/MooreCaches.java
+++ b/filters/cache/src/main/java/de/learnlib/filter/cache/moore/MooreCaches.java
@@ -42,6 +42,10 @@ public final class MooreCaches {
      *         the input alphabet
      * @param mqOracle
      *         the membership oracle
+     * @param <I>
+     *         input symbol type
+     * @param <O>
+     *         output symbol type
      *
      * @return a Moore learning cache with a default implementation
      */
@@ -57,6 +61,10 @@ public final class MooreCaches {
      *         the input alphabet
      * @param mqOracle
      *         the membership oracle
+     * @param <I>
+     *         input symbol type
+     * @param <O>
+     *         output symbol type
      *
      * @return a Moore learning cache with a DAG-based implementation
      *
@@ -76,6 +84,10 @@ public final class MooreCaches {
      *         a mapping for the prefix-closure filter
      * @param mqOracle
      *         the membership oracle
+     * @param <I>
+     *         input symbol type
+     * @param <O>
+     *         output symbol type
      *
      * @return a Moore learning cache with a DAG-based implementation
      *
@@ -94,6 +106,10 @@ public final class MooreCaches {
      *         the input alphabet
      * @param mqOracle
      *         the membership oracle
+     * @param <I>
+     *         input symbol type
+     * @param <O>
+     *         output symbol type
      *
      * @return a Moore learning cache with a tree-based implementation
      *
@@ -113,6 +129,10 @@ public final class MooreCaches {
      *         a mapping for the prefix-closure filter
      * @param mqOracle
      *         the membership oracle
+     * @param <I>
+     *         input symbol type
+     * @param <O>
+     *         output symbol type
      *
      * @return a Moore learning cache with a tree-based implementation
      *

--- a/filters/cache/src/main/java/de/learnlib/filter/cache/sul/SULCaches.java
+++ b/filters/cache/src/main/java/de/learnlib/filter/cache/sul/SULCaches.java
@@ -40,6 +40,10 @@ public final class SULCaches {
      *         the input alphabet
      * @param sul
      *         the sul
+     * @param <I>
+     *         input symbol type
+     * @param <O>
+     *         output symbol type
      *
      * @return a {@link SULCache} with a default implementation
      */
@@ -54,6 +58,10 @@ public final class SULCaches {
      *         the input alphabet
      * @param sul
      *         the sul
+     * @param <I>
+     *         input symbol type
+     * @param <O>
+     *         output symbol type
      *
      * @return a {@link SULCache} with a DAG-based implementation
      *
@@ -70,6 +78,10 @@ public final class SULCaches {
      *         the input alphabet
      * @param sul
      *         the sul
+     * @param <I>
+     *         input symbol type
+     * @param <O>
+     *         output symbol type
      *
      * @return a {@link SULCache} with a tree-based implementation
      *
@@ -89,6 +101,10 @@ public final class SULCaches {
      *         the input alphabet
      * @param sul
      *         the sul
+     * @param <I>
+     *         input symbol type
+     * @param <O>
+     *         output symbol type
      *
      * @return a {@link StateLocalInputSULCache} with a default implementation
      */
@@ -105,6 +121,10 @@ public final class SULCaches {
      *         the input alphabet
      * @param sul
      *         the sul
+     * @param <I>
+     *         input symbol type
+     * @param <O>
+     *         output symbol type
      *
      * @return a {@link StateLocalInputSULCache} with a tree-based implementation
      *

--- a/filters/reuse/src/main/java/de/learnlib/filter/reuse/ReuseOracle.java
+++ b/filters/reuse/src/main/java/de/learnlib/filter/reuse/ReuseOracle.java
@@ -66,6 +66,25 @@ public final class ReuseOracle<S, I, O> implements SingleQueryOracleMealy<I, O> 
 
     /**
      * Default constructor.
+     *
+     * @param alphabet
+     *         the input alphabet of the system
+     * @param oracleSupplier
+     *         a supplier for reusable oracles
+     * @param enabledSystemStateInvalidation
+     *         a flag whether system states should be invalidated after retrieval
+     * @param systemStateHandler
+     *         the handler for notification about system state removals
+     * @param invariantInputs
+     *         the set of symbols that behave invariant
+     * @param failureOutputs
+     *         the set of symbols of failed system outputs
+     * @param maxSystemStates
+     *         the maximum number of stored system states
+     * @param accessPolicy
+     *         the strategy for accessing elements
+     * @param evictPolicy
+     *         the strategy for evicting elements of the capacity is reached
      */
     @GenerateBuilder(defaults = BuilderDefaults.class,
                      getterPrefix = GenerateBuilder.SUPPRESS,
@@ -156,6 +175,8 @@ public final class ReuseOracle<S, I, O> implements SingleQueryOracleMealy<I, O> 
 
     /**
      * Returns the {@link ReuseCapableOracle} used by this instance.
+     *
+     * @return the oracle used by this instance
      */
     public ReuseCapableOracle<S, I, O> getReuseCapableOracle() {
         return executableOracles.get();
@@ -209,6 +230,8 @@ public final class ReuseOracle<S, I, O> implements SingleQueryOracleMealy<I, O> 
 
     /**
      * Returns the {@link ReuseTree} used by this instance.
+     *
+     * @return the reuse tree used by this instance
      */
     public ReuseTree<S, I, O> getReuseTree() {
         return this.tree;

--- a/filters/reuse/src/main/java/de/learnlib/filter/reuse/tree/ReuseNode.java
+++ b/filters/reuse/src/main/java/de/learnlib/filter/reuse/tree/ReuseNode.java
@@ -24,7 +24,7 @@ import de.learnlib.filter.reuse.tree.BoundedDeque.EvictPolicy;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * A {@link ReuseNode} is a vertex in the {@link ReuseTree} that contains (a possible empty) set of outgoing {@link
+ * A {@link ReuseNode} is a vertex in the {@link ReuseTree} that contains (a possibly empty) set of outgoing {@link
  * ReuseEdge}s. Each {@link ReuseNode} may contain a system state holding relevant information (e.g. database
  * identifiers or an object) that belongs to the system state that 'represents' the system state after executing a
  * membership query.
@@ -54,7 +54,12 @@ public class ReuseNode<S, I, O> {
     }
 
     /**
-     * The system state, may be {@code null}.
+     * Retrieve a system state.
+     *
+     * @param remove
+     *         a flag whether the system state should be removed from the internal storage after retrieval
+     *
+     * @return a system state, May be {@code null}.
      */
     public S fetchSystemState(boolean remove) {
         if (remove) {
@@ -80,8 +85,9 @@ public class ReuseNode<S, I, O> {
     }
 
     /**
-     * Returns all outgoing {@link ReuseEdge}s from this {@link ReuseNode}. If there are none the returned {@link
-     * java.util.Collection} will be empty (but never {@code null}).
+     * Returns all outgoing {@link ReuseEdge}s from this {@link ReuseNode}.
+     *
+     * @return the outgoing edges of this node
      */
     public Collection<@Nullable ReuseEdge<S, I, O>> getEdges() {
         return Arrays.asList(edges);
@@ -89,6 +95,11 @@ public class ReuseNode<S, I, O> {
 
     /**
      * Adds an outgoing {@link ReuseEdge} to this {@link ReuseNode}.
+     *
+     * @param index
+     *         the position (index) of the edge to add
+     * @param edge
+     *         the edge to add
      */
     public void addEdge(int index, ReuseEdge<S, I, O> edge) {
         this.edges[index] = edge;
@@ -103,7 +114,12 @@ public class ReuseNode<S, I, O> {
     }
 
     /**
-     * May be {@code null}.
+     * Return the edge with the given index.
+     *
+     * @param index
+     *         the index of the edge
+     *
+     * @return the edge with the given index. May be {@code null}.
      */
     public @Nullable ReuseEdge<S, I, O> getEdgeWithInput(int index) {
         return this.edges[index];

--- a/filters/reuse/src/main/java/de/learnlib/filter/reuse/tree/ReuseTree.java
+++ b/filters/reuse/src/main/java/de/learnlib/filter/reuse/tree/ReuseTree.java
@@ -242,12 +242,13 @@ public final class ReuseTree<S, I, O> implements Graph<@Nullable ReuseNode<S, I,
     }
 
     /**
-     * Returns a reuseable {@link ReuseNode.NodeResult} with system state or {@code null} if none such exists. If
-     * ''oldInvalidated'' was set to {@code true} (in the {@link ReuseOracle}) the system state is already removed from
-     * the tree whenever one was available.
+     * Returns a reusable {@link ReuseNode.NodeResult} with system state accessed by the given access sequence. or
+     * {@code null} if none such exists.
      *
      * @param query
-     *         Not allowed to be {@code null}.
+     *         the access sequence to the node
+     *
+     * @return the node accessed by the given query, {@code null} if no such node exists
      */
     public ReuseNode.@Nullable NodeResult<S, I, O> fetchSystemState(Word<I> query) {
         if (query == null) {
@@ -305,6 +306,11 @@ public final class ReuseTree<S, I, O> implements Graph<@Nullable ReuseNode<S, I,
      * This method should only be invoked internally from the {@link ReuseOracle} unless you know exactly what you are
      * doing (you may want to create a predefined reuse tree before start learning).
      *
+     * @param query
+     *         the query determining a path in the tree
+     * @param queryResult
+     *         the output that should be associated with the given path
+     *
      * @throws ReuseException
      *         if non-deterministic behavior is detected
      */
@@ -324,6 +330,13 @@ public final class ReuseTree<S, I, O> implements Graph<@Nullable ReuseNode<S, I,
      * <p>
      * This method should only be invoked internally from the {@link ReuseOracle} unless you know exactly what you are
      * doing (you may want to create a predefined reuse tree before start learning).
+     *
+     * @param query
+     *         the query determining a path in the tree
+     * @param sink
+     *         the starting node of the path
+     * @param queryResult
+     *         the output that should be associated with the given path
      *
      * @throws ReuseException
      *         if non-deterministic behavior is detected

--- a/filters/reuse/src/main/java/de/learnlib/filter/reuse/tree/SystemStateHandler.java
+++ b/filters/reuse/src/main/java/de/learnlib/filter/reuse/tree/SystemStateHandler.java
@@ -22,8 +22,8 @@ import de.learnlib.filter.reuse.ReuseOracleBuilder;
  * {@link ReuseOracleBuilder#withSystemStateHandler(SystemStateHandler)}) will be informed about all removed system
  * states whenever {@link ReuseTree#disposeSystemStates()} gets called.
  * <p>
- * The objective of this handler is that clearing system states from the reuse tree may also be resulting in cleaning up
- * the SUL by e.g. perform tasks like removing persisted entities from a database.
+ * The objective of this handler is that clearing system states from the reuse tree may also result in cleaning up the
+ * SUL by e.g. perform tasks like removing persisted entities from a database.
  * <p>
  * Please note that the normal removal of system states (by sifting them down in the reuse tree by executing only
  * suffixes of a query) is not be seen as a disposing.

--- a/oracles/membership-oracles/src/main/java/de/learnlib/oracle/membership/AbstractSULOmegaOracle.java
+++ b/oracles/membership-oracles/src/main/java/de/learnlib/oracle/membership/AbstractSULOmegaOracle.java
@@ -99,7 +99,7 @@ public abstract class AbstractSULOmegaOracle<S extends Object, I, O, Q> implemen
                 final Q nextState = getQueryState(sul);
 
                 int prefixLength = prefix.length();
-                for (Q q: states) {
+                for (Q q : states) {
                     if (isSameState(inputBuilder.toWord(), nextState, inputBuilder.toWord(0, prefixLength), q)) {
                         return Pair.of(outputBuilder.toWord(), i + 1);
                     }
@@ -123,12 +123,16 @@ public abstract class AbstractSULOmegaOracle<S extends Object, I, O, Q> implemen
      * Creates a new {@link AbstractSULOmegaOracle}, while making sure the invariants of the {@link ObservableSUL} are
      * satisfied.
      *
-     * @param sul the {@link ObservableSUL} to wrap around.
-     * @param deepCopies whether to test for state equivalence directly on the retrieved state.
-     *
-     * @param <S> the state type
-     * @param <I> the input type
-     * @param <O> the output type
+     * @param sul
+     *         the {@link ObservableSUL} to wrap around.
+     * @param deepCopies
+     *         whether to test for state equivalence directly on the retrieved state.
+     * @param <S>
+     *         the state type
+     * @param <I>
+     *         the input type
+     * @param <O>
+     *         the output type
      *
      * @return the {@link AbstractSULOmegaOracle}.
      */
@@ -155,11 +159,18 @@ public abstract class AbstractSULOmegaOracle<S extends Object, I, O, Q> implemen
     /**
      * Creates a new {@link AbstractSULOmegaOracle} that assumes the {@link SUL} can not make deep copies.
      *
-     * @see #newOracle(ObservableSUL, boolean)
+     * @param sul
+     *         the sul to delegate queris to
+     * @param <S>
+     *         the state type
+     * @param <I>
+     *         the input type
+     * @param <O>
+     *         the output type
      *
-     * @param <S> the state type
-     * @param <I> the input type
-     * @param <O> the output type
+     * @return the new oracle
+     *
+     * @see #newOracle(ObservableSUL, boolean)
      */
     public static <S extends Object, I, O> AbstractSULOmegaOracle<S, I, O, ?> newOracle(ObservableSUL<S, I, O> sul) {
         return newOracle(sul, !sul.canFork());
@@ -173,9 +184,12 @@ public abstract class AbstractSULOmegaOracle<S extends Object, I, O, Q> implemen
      * The state information used to answer {@link OmegaQuery}s is of type {@link Integer}. The values of those integers
      * are actually hash codes of states of the {@link ObservableSUL}.
      *
-     * @param <S> the state type
-     * @param <I> the input type
-     * @param <O> the output type
+     * @param <S>
+     *         the state type
+     * @param <I>
+     *         the input type
+     * @param <O>
+     *         the output type
      */
     private static final class ShallowCopySULOmegaOracle<S extends Object, I, O>
             extends AbstractSULOmegaOracle<S, I, O, Integer> {
@@ -187,10 +201,11 @@ public abstract class AbstractSULOmegaOracle<S extends Object, I, O, Q> implemen
 
         /**
          * Constructs a new {@link ShallowCopySULOmegaOracle}, use {@link #newOracle(ObservableSUL)} to create an
-         * instance. This method makes sure the invariants of the {@link ObservableSUL} are satisfied (i.e., the {@link
-         * ObservableSUL} must be forkable, i.e. ({@code {@link SUL#canFork()} == true}).
+         * instance. This method makes sure the invariants of the {@link ObservableSUL} are satisfied (i.e., the
+         * {@link ObservableSUL} must be forkable, i.e. ({@code {@link SUL#canFork()} == true}).
          *
-         * @param sul the SUL
+         * @param sul
+         *         the SUL
          */
         ShallowCopySULOmegaOracle(ObservableSUL<S, I, O> sul) {
             super(sul);
@@ -201,7 +216,8 @@ public abstract class AbstractSULOmegaOracle<S extends Object, I, O, Q> implemen
         /**
          * Returns the state as a hash code.
          *
-         * @param sul the {@link ObservableSUL} to retrieve the current state from.
+         * @param sul
+         *         the {@link ObservableSUL} to retrieve the current state from.
          *
          * @return the hash code of the state.
          */
@@ -213,11 +229,13 @@ public abstract class AbstractSULOmegaOracle<S extends Object, I, O, Q> implemen
         /**
          * Test for state equivalence, by means of {@link Object#hashCode()}, and {@link Object#equals(Object)}.
          *
-         * @see OmegaMembershipOracle#isSameState(Word, Object, Word, Object)
-         *
          * @return whether the following conditions hold:
-         *  1. the hash codes are the same, i.e. {@code s1.equals(s2)}, and
-         *  2. the two access sequences lead to the same state.
+         * <ol>
+         *     <li>the hash codes are the same, i.e. {@code s1.equals(s2)}, and</li>
+         *     <li>the two access sequences lead to the same state.</li>
+         * </ol>
+         *
+         * @see OmegaMembershipOracle#isSameState(Word, Object, Word, Object)
          */
         @Override
         public boolean isSameState(Word<I> input1, Integer s1, Word<I> input2, Integer s2) {
@@ -256,9 +274,12 @@ public abstract class AbstractSULOmegaOracle<S extends Object, I, O, Q> implemen
      * <p>
      * The state information used to answer {@link OmegaQuery}s is of type {@link S}.
      *
-     * @param <S> the state type
-     * @param <I> the input type
-     * @param <O> the output type
+     * @param <S>
+     *         the state type
+     * @param <I>
+     *         the input type
+     * @param <O>
+     *         the output type
      */
     private static final class DeepCopySULOmegaOracle<S extends Object, I, O>
             extends AbstractSULOmegaOracle<S, I, O, S> {
@@ -267,7 +288,8 @@ public abstract class AbstractSULOmegaOracle<S extends Object, I, O, Q> implemen
          * Constructs a {@link DeepCopySULOmegaOracle}, use {@link #newOracle(ObservableSUL, boolean)} to create an
          * actual instance. This method will make sure the invariants of the {@link ObservableSUL} are satisfied.
          *
-         * @param sul the {@link ObservableSUL}.
+         * @param sul
+         *         the {@link ObservableSUL}.
          */
         DeepCopySULOmegaOracle(ObservableSUL<S, I, O> sul) {
             super(sul);
@@ -276,7 +298,8 @@ public abstract class AbstractSULOmegaOracle<S extends Object, I, O, Q> implemen
         /**
          * Returns the current state of the {@link ObservableSUL}.
          *
-         * @param sul the {@link ObservableSUL} to retrieve the current state from.
+         * @param sul
+         *         the {@link ObservableSUL} to retrieve the current state from.
          *
          * @return the current state.
          */

--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,8 @@ limitations under the License.
         <maven.compiler.testRelease>11</maven.compiler.testRelease>
         <argLine /> <!-- compatibility for property expansion in surefire-plugin -->
 
+        <learnlib.jdk16orLower>false</learnlib.jdk16orLower>
+
         <!-- plugin versions -->
         <antrun-plugin.version>3.1.0</antrun-plugin.version>
         <archetype-plugin.version>3.2.1</archetype-plugin.version>
@@ -1008,6 +1010,10 @@ limitations under the License.
         <profile>
             <!-- enables additional plugins that perform static code analysis, also see the 'build-parent' pom -->
             <id>code-analysis</id>
+            <properties>
+                <!-- from JDK17 onward, all missing javadoc generates warnings. we don't support that yet -->
+                <maven.javadoc.failOnWarnings>${learnlib.jdk16orLower}</maven.javadoc.failOnWarnings>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -1219,6 +1225,15 @@ limitations under the License.
             </activation>
             <properties>
                 <cacio.version>1.17.3</cacio.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk16orLower</id>
+            <activation>
+                <jdk>(,17)</jdk>
+            </activation>
+            <properties>
+                <learnlib.jdk16orLower>true</learnlib.jdk16orLower>
             </properties>
         </profile>
         <profile>

--- a/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/AbstractDFALearnerIT.java
+++ b/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/AbstractDFALearnerIT.java
@@ -75,6 +75,8 @@ public abstract class AbstractDFALearnerIT {
      *         the membership oracle
      * @param variants
      *         list to add the learner variants to
+     * @param <I>
+     *         input symbol type
      */
     protected abstract <I> void addLearnerVariants(Alphabet<I> alphabet,
                                                    int targetSize,

--- a/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/AbstractDFAPassiveLearnerIT.java
+++ b/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/AbstractDFAPassiveLearnerIT.java
@@ -93,6 +93,8 @@ public abstract class AbstractDFAPassiveLearnerIT {
      *         the input alphabet
      * @param variants
      *         list to add the learner variants to
+     * @param <I>
+     *         input symbol type
      */
     protected abstract <I> void addLearnerVariants(Alphabet<I> alphabet,
                                                    PassiveLearnerVariantList<DFA<?, I>, I, Boolean> variants);

--- a/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/AbstractMealyLearnerIT.java
+++ b/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/AbstractMealyLearnerIT.java
@@ -110,6 +110,10 @@ public abstract class AbstractMealyLearnerIT {
      *         the membership oracle
      * @param variants
      *         list to add the learner variants to
+     * @param <I>
+     *         input symbol type
+     * @param <O>
+     *         output symbol type
      */
     protected abstract <I, O> void addLearnerVariants(Alphabet<I> alphabet,
                                                       int targetSize,

--- a/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/AbstractMealyPassiveLearnerIT.java
+++ b/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/AbstractMealyPassiveLearnerIT.java
@@ -74,6 +74,10 @@ public abstract class AbstractMealyPassiveLearnerIT {
      *         the input alphabet
      * @param variants
      *         list to add the learner variants to
+     * @param <I>
+     *         input symbol type
+     * @param <O>
+     *         output symbol type
      */
     protected abstract <I, O> void addLearnerVariants(Alphabet<I> alphabet,
                                                       PassiveLearnerVariantList<MealyMachine<?, I, ?, O>, I, Word<O>> variants);

--- a/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/AbstractMealySymLearnerIT.java
+++ b/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/AbstractMealySymLearnerIT.java
@@ -76,6 +76,10 @@ public abstract class AbstractMealySymLearnerIT {
      *         the membership oracle
      * @param variants
      *         list to add the learner variants to
+     * @param <I>
+     *         input symbol type
+     * @param <O>
+     *         output symbol type
      */
     protected abstract <I, O> void addLearnerVariants(Alphabet<I> alphabet,
                                                       MembershipOracle<I, O> mqOracle,

--- a/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/AbstractMooreLearnerIT.java
+++ b/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/AbstractMooreLearnerIT.java
@@ -76,6 +76,10 @@ public abstract class AbstractMooreLearnerIT {
      *         the membership oracle
      * @param variants
      *         list to add the learner variants to
+     * @param <I>
+     *         input symbol type
+     * @param <O>
+     *         output symbol type
      */
     protected abstract <I, O> void addLearnerVariants(Alphabet<I> alphabet,
                                                       int targetSize,

--- a/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/AbstractMoorePassiveLearnerIT.java
+++ b/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/AbstractMoorePassiveLearnerIT.java
@@ -74,6 +74,10 @@ public abstract class AbstractMoorePassiveLearnerIT {
      *         the input alphabet
      * @param variants
      *         list to add the learner variants to
+     * @param <I>
+     *         input symbol type
+     * @param <O>
+     *         output symbol type
      */
     protected abstract <I, O> void addLearnerVariants(Alphabet<I> alphabet,
                                                       PassiveLearnerVariantList<MooreMachine<?, I, ?, O>, I, Word<O>> variants);

--- a/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/AbstractMooreSymLearnerIT.java
+++ b/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/AbstractMooreSymLearnerIT.java
@@ -76,6 +76,10 @@ public abstract class AbstractMooreSymLearnerIT {
      *         the membership oracle
      * @param variants
      *         list to add the learner variants to
+     * @param <I>
+     *         input symbol type
+     * @param <O>
+     *         output symbol type
      */
     protected abstract <I, O> void addLearnerVariants(Alphabet<I> alphabet,
                                                       MembershipOracle<I, O> mqOracle,

--- a/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/AbstractOneSEVPALearnerIT.java
+++ b/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/AbstractOneSEVPALearnerIT.java
@@ -67,6 +67,8 @@ public abstract class AbstractOneSEVPALearnerIT {
      *         the membership oracle
      * @param variants
      *         list to add the learner variants to
+     * @param <I>
+     *         input symbol type
      */
     protected abstract <I> void addLearnerVariants(VPAlphabet<I> alphabet,
                                                    DFAMembershipOracle<I> mqOracle,

--- a/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/AbstractSBALearnerIT.java
+++ b/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/AbstractSBALearnerIT.java
@@ -68,6 +68,8 @@ public abstract class AbstractSBALearnerIT {
      *         the membership oracle
      * @param variants
      *         list to add the learner variants to
+     * @param <I>
+     *         input symbol type
      */
     protected abstract <I> void addLearnerVariants(ProceduralInputAlphabet<I> alphabet,
                                                    DFAMembershipOracle<I> mqOracle,

--- a/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/AbstractSPALearnerIT.java
+++ b/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/AbstractSPALearnerIT.java
@@ -68,6 +68,8 @@ public abstract class AbstractSPALearnerIT {
      *         the membership oracle
      * @param variants
      *         list to add the learner variants to
+     * @param <I>
+     *         input symbol type
      */
     protected abstract <I> void addLearnerVariants(ProceduralInputAlphabet<I> alphabet,
                                                    DFAMembershipOracle<I> mqOracle,

--- a/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/AbstractSPMMLearnerIT.java
+++ b/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/AbstractSPMMLearnerIT.java
@@ -68,6 +68,10 @@ public abstract class AbstractSPMMLearnerIT {
      *         the membership oracle
      * @param variants
      *         list to add the learner variants to
+     * @param <I>
+     *         input symbol type
+     * @param <O>
+     *         output symbol type
      */
     protected abstract <I, O> void addLearnerVariants(ProceduralInputAlphabet<I> alphabet,
                                                       O errorOutput,

--- a/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/AbstractSSTPassiveLearnerIT.java
+++ b/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/AbstractSSTPassiveLearnerIT.java
@@ -81,6 +81,10 @@ public abstract class AbstractSSTPassiveLearnerIT {
      *         the input alphabet
      * @param variants
      *         list to add the learner variants to
+     * @param <I>
+     *         input symbol type
+     * @param <O>
+     *         output symbol type
      */
     protected abstract <I, O> void addLearnerVariants(Alphabet<I> alphabet,
                                                       PassiveLearnerVariantList<SubsequentialTransducer<?, I, ?, O>, I, Word<O>> variants);

--- a/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/LearnerITUtil.java
+++ b/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/LearnerITUtil.java
@@ -63,6 +63,19 @@ public final class LearnerITUtil {
     /**
      * Creates a list of per-example test cases for all learner variants.
      *
+     * @param example
+     *         the example system
+     * @param variants
+     *         the list containing the various learner variants
+     * @param eqOracle
+     *         the equivalence oracle to use by the learning process
+     * @param <I>
+     *         input symbol type
+     * @param <D>
+     *         output domain type
+     * @param <A>
+     *         automaton type
+     *
      * @return the list of test cases, one for each example
      */
     public static <I, D, A extends UniversalDeterministicAutomaton<?, I, ?, ?, ?>> List<UniversalDeterministicLearnerITCase<I, D, A>> createExampleITCases(
@@ -80,6 +93,15 @@ public final class LearnerITUtil {
     /**
      * Creates a list of per-example test cases for all learner variants.
      *
+     * @param example
+     *         the example system
+     * @param variants
+     *         the list containing the various learner variants
+     * @param eqOracle
+     *         the equivalence oracle to use by the learning process
+     * @param <I>
+     *         input symbol type
+     *
      * @return the list of test cases, one for each example
      */
     public static <I> List<SPALearnerITCase<I>> createExampleITCases(SPALearningExample<I> example,
@@ -95,6 +117,15 @@ public final class LearnerITUtil {
 
     /**
      * Creates a list of per-example test cases for all learner variants.
+     *
+     * @param example
+     *         the example system
+     * @param variants
+     *         the list containing the various learner variants
+     * @param eqOracle
+     *         the equivalence oracle to use by the learning process
+     * @param <I>
+     *         input symbol type
      *
      * @return the list of test cases, one for each example
      */
@@ -112,6 +143,17 @@ public final class LearnerITUtil {
     /**
      * Creates a list of per-example test cases for all learner variants.
      *
+     * @param example
+     *         the example system
+     * @param variants
+     *         the list containing the various learner variants
+     * @param eqOracle
+     *         the equivalence oracle to use by the learning process
+     * @param <I>
+     *         input symbol type
+     * @param <O>
+     *         output symbol type
+     *
      * @return the list of test cases, one for each example
      */
     public static <I, O> List<SPMMLearnerITCase<I, O>> createExampleITCases(SPMMLearningExample<I, O> example,
@@ -127,6 +169,15 @@ public final class LearnerITUtil {
 
     /**
      * Creates a list of per-example test cases for all learner variants.
+     *
+     * @param example
+     *         the example system
+     * @param variants
+     *         the list containing the various learner variants
+     * @param eqOracle
+     *         the equivalence oracle to use by the learning process
+     * @param <I>
+     *         input symbol type
      *
      * @return the list of test cases, one for each example
      */
@@ -159,6 +210,17 @@ public final class LearnerITUtil {
 
     /**
      * Creates a list of per-example test cases for all learner variants (passive version).
+     *
+     * @param example
+     *         the example system
+     * @param variants
+     *         the list containing the various learner variants
+     * @param <I>
+     *         input symbol type
+     * @param <D>
+     *         output domain type
+     * @param <A>
+     *         automaton type
      *
      * @return the list of test cases, one for each example
      */

--- a/test-support/learning-examples/src/main/java/de/learnlib/testsupport/example/mealy/ExampleCoffeeMachine.java
+++ b/test-support/learning-examples/src/main/java/de/learnlib/testsupport/example/mealy/ExampleCoffeeMachine.java
@@ -44,6 +44,15 @@ public class ExampleCoffeeMachine extends DefaultMealyLearningExample<Input, Str
     /**
      * Construct and return a machine representation of this example.
      *
+     * @param machine
+     *         the output object to write the contents to
+     * @param <S>
+     *         state type
+     * @param <T>
+     *         transition type
+     * @param <A>
+     *         automaton type
+     *
      * @return a Mealy machine representing the coffee machine example
      */
     public static <S, T, A extends MutableMealyMachine<S, ? super Input, T, ? super String>> A constructMachine(A machine) {

--- a/test-support/learning-examples/src/main/java/de/learnlib/testsupport/example/mealy/ExampleGrid.java
+++ b/test-support/learning-examples/src/main/java/de/learnlib/testsupport/example/mealy/ExampleGrid.java
@@ -38,10 +38,16 @@ public class ExampleGrid extends DefaultMealyLearningExample<Character, Integer>
     /**
      * Construct and return a machine representation of this example.
      *
+     * @param fm
+     *         the output object to write the contents to
      * @param xsize
      *         number of states in x direction
      * @param ysize
      *         number of states in y direction
+     * @param <S>
+     *         state type
+     * @param <A>
+     *         automaton type
      *
      * @return a Mealy machine with (xsize * ysize) states
      */

--- a/test-support/learning-examples/src/main/java/de/learnlib/testsupport/example/mealy/ExampleShahbazGroz.java
+++ b/test-support/learning-examples/src/main/java/de/learnlib/testsupport/example/mealy/ExampleShahbazGroz.java
@@ -39,6 +39,15 @@ public class ExampleShahbazGroz extends DefaultMealyLearningExample<Character, S
     /**
      * Construct and return a machine representation of this example.
      *
+     * @param fm
+     *         the output object to write the contents to
+     * @param <S>
+     *         state type
+     * @param <T>
+     *         transition type
+     * @param <A>
+     *         automaton type
+     *
      * @return machine instance of the example
      */
     public static <S, T, A extends MutableMealyMachine<S, ? super Character, T, ? super String>> A constructMachine(A fm) {

--- a/test-support/learning-examples/src/main/java/de/learnlib/testsupport/example/mealy/ExampleStack.java
+++ b/test-support/learning-examples/src/main/java/de/learnlib/testsupport/example/mealy/ExampleStack.java
@@ -41,6 +41,15 @@ public class ExampleStack extends DefaultMealyLearningExample<Input, Output> {
     /**
      * Construct and return a machine representation of this example.
      *
+     * @param fm
+     *         the output object to write the contents to
+     * @param <S>
+     *         state type
+     * @param <T>
+     *         transition type
+     * @param <A>
+     *         automaton type
+     *
      * @return machine instance of the example
      */
     public static <S, T, A extends MutableMealyMachine<S, ? super Input, T, ? super Output>> A constructMachine(A fm) {


### PR DESCRIPTION
This PR fixes all reported warnings from the javadoc linter and enables linting in the `code-analysis` profile for future use.

Note that the linting is restricted to JDKs < 17 for now, since newer JDKs warn on any missing documentation. The aim of this PR is to address *incomplete* documentation only for now.


Closes #102.