### PR TITLE
Replace xstream with fury

### DIFF
--- a/algorithms/active/lstar/pom.xml
+++ b/algorithms/active/lstar/pom.xml
@@ -140,30 +140,4 @@ limitations under the License.
             </plugins>
         </pluginManagement>
     </build>
-
-    <profiles>
-        <profile>
-            <id>fix-xstream</id>
-            <activation>
-                <jdk>[16,)</jdk>
-            </activation>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-surefire-plugin</artifactId>
-                            <configuration>
-                                <argLine>
-                                    @{argLine}
-                                    --add-reads=de.learnlib.algorithm.lstar=net.automatalib.util
-                                    --add-opens=java.base/java.util=ALL-UNNAMED
-                                </argLine>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/algorithms/active/pom.xml
+++ b/algorithms/active/pom.xml
@@ -45,26 +45,4 @@ limitations under the License.
         <module>ttt</module>
         <module>ttt-vpa</module>
     </modules>
-
-    <profiles>
-        <profile>
-            <id>fix-xstream</id>
-            <activation>
-                <jdk>[16,)</jdk>
-            </activation>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-surefire-plugin</artifactId>
-                            <configuration>
-                                <argLine>@{argLine} --add-opens=java.base/java.util=ALL-UNNAMED</argLine>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -112,6 +112,12 @@ limitations under the License.
             <artifactId>learnlib-statistics</artifactId>
         </dependency>
         <dependency>
+            <groupId>de.learnlib.testsupport</groupId>
+            <artifactId>learnlib-test-support</artifactId>
+            <scope>compile</scope>
+            <!-- Override! -->
+        </dependency>
+        <dependency>
             <groupId>de.learnlib</groupId>
             <artifactId>learnlib-ttt</artifactId>
         </dependency>
@@ -125,11 +131,6 @@ limitations under the License.
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.thoughtworks.xstream</groupId>
-            <artifactId>xstream</artifactId>
         </dependency>
 
         <dependency>
@@ -200,8 +201,6 @@ limitations under the License.
                             <java.awt.graphicsenv>com.github.caciocavallosilano.cacio.ctc.CTCGraphicsEnvironment</java.awt.graphicsenv>
                             <java.awt.headless>false</java.awt.headless>
                         </systemPropertyVariables>
-                        <!-- append to existing argLine to nicely work together with jacoco plugin -->
-                        <argLine>@{argLine} --add-opens=java.base/java.util=xstream</argLine>
                     </configuration>
                 </plugin>
             </plugins>

--- a/examples/src/main/java/module-info.java
+++ b/examples/src/main/java/module-info.java
@@ -41,6 +41,7 @@ open module de.learnlib.example {
     requires de.learnlib.oracle.membership;
     requires de.learnlib.oracle.parallelism;
     requires de.learnlib.oracle.property;
+    requires de.learnlib.testsupport;
     requires de.learnlib.testsupport.example;
     requires net.automatalib.api;
     requires net.automatalib.common.util;
@@ -49,7 +50,6 @@ open module de.learnlib.example {
     requires net.automatalib.util;
     requires net.automatalib.serialization.dot;
     requires net.automatalib.visualization.dot;
-    requires xstream;
 
     // make non-static once https://github.com/typetools/checker-framework/issues/4559 is implemented
     requires static org.checkerframework.checker.qual;

--- a/filters/cache/pom.xml
+++ b/filters/cache/pom.xml
@@ -129,32 +129,4 @@ limitations under the License.
             </plugins>
         </pluginManagement>
     </build>
-
-    <profiles>
-        <profile>
-            <id>fix-xstream</id>
-            <activation>
-                <jdk>[16,)</jdk>
-            </activation>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-surefire-plugin</artifactId>
-                            <configuration>
-                                <argLine>
-                                    @{argLine}
-                                    --add-opens=java.base/java.util=ALL-UNNAMED
-                                    --add-reads=de.learnlib.filter.cache=de.learnlib.filter.statistic
-                                    --add-reads=de.learnlib.filter.cache=de.learnlib.oracle.membership
-                                    --add-reads=de.learnlib.filter.cache=de.learnlib.oracle.parallelism
-                                </argLine>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -244,13 +244,14 @@ limitations under the License.
         <cacio.version>1.11.1</cacio.version>
         <checkerframework.version>3.40.0</checkerframework.version>
         <checkstyle.version>9.3</checkstyle.version>
+        <fury.version>0.4.1</fury.version>
+        <javapoet.version>1.13.0</javapoet.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <logback.version>1.3.12</logback.version>
         <metainf-services.version>1.11</metainf-services.version>
         <mockito.version>5.6.0</mockito.version>
         <slf4j.version>2.0.9</slf4j.version>
-        <testng.version>7.5.1</testng.version>
-        <xstream.version>1.4.20</xstream.version>
+        <testng.version>7.9.0</testng.version>
 
         <!-- Javadoc links -->
         <automatalib.apidocs>http://learnlib.github.io/automatalib/maven-site/${automatalib.version}/apidocs/</automatalib.apidocs>
@@ -615,9 +616,9 @@ limitations under the License.
             </dependency>
 
             <dependency>
-                <groupId>com.thoughtworks.xstream</groupId>
-                <artifactId>xstream</artifactId>
-                <version>${xstream.version}</version>
+                <groupId>org.furyio</groupId>
+                <artifactId>fury-core</artifactId>
+                <version>${fury.version}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@ limitations under the License.
         <cacio.version>1.11.1</cacio.version>
         <checkerframework.version>3.40.0</checkerframework.version>
         <checkstyle.version>9.3</checkstyle.version>
-        <fury.version>0.5.0-SNAPSHOT</fury.version>
+        <fury.version>0.5.0</fury.version>
         <javapoet.version>1.13.0</javapoet.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <logback.version>1.3.12</logback.version>
@@ -648,25 +648,6 @@ limitations under the License.
 
         </dependencies>
     </dependencyManagement>
-
-    <repositories>
-        <!-- explicitly name maven-central, so it is queried first -->
-        <repository>
-            <id>maven-central</id>
-            <name>Maven Central Repository</name>
-            <url>https://repo.maven.apache.org/maven2/</url>
-        </repository>
-        <repository>
-            <id>apache</id>
-            <url>https://repository.apache.org/snapshots/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 
     <!--
     ================================= BUILD PLUGINS =============================

--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@ limitations under the License.
         <cacio.version>1.11.1</cacio.version>
         <checkerframework.version>3.40.0</checkerframework.version>
         <checkstyle.version>9.3</checkstyle.version>
-        <fury.version>0.4.1</fury.version>
+        <fury.version>0.5.0-SNAPSHOT</fury.version>
         <javapoet.version>1.13.0</javapoet.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <logback.version>1.3.12</logback.version>
@@ -616,7 +616,7 @@ limitations under the License.
             </dependency>
 
             <dependency>
-                <groupId>org.furyio</groupId>
+                <groupId>org.apache.fury</groupId>
                 <artifactId>fury-core</artifactId>
                 <version>${fury.version}</version>
             </dependency>
@@ -648,6 +648,25 @@ limitations under the License.
 
         </dependencies>
     </dependencyManagement>
+
+    <repositories>
+        <!-- explicitly name maven-central, so it is queried first -->
+        <repository>
+            <id>maven-central</id>
+            <name>Maven Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2/</url>
+        </repository>
+        <repository>
+            <id>apache</id>
+            <url>https://repository.apache.org/snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 
     <!--
     ================================= BUILD PLUGINS =============================

--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@ limitations under the License.
         <cacio.version>1.11.1</cacio.version>
         <checkerframework.version>3.40.0</checkerframework.version>
         <checkstyle.version>9.3</checkstyle.version>
-        <fury.version>0.5.0</fury.version>
+        <fury.version>0.5.1</fury.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <logback.version>1.3.12</logback.version>
         <metainf-services.version>1.11</metainf-services.version>

--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,6 @@ limitations under the License.
         <checkerframework.version>3.40.0</checkerframework.version>
         <checkstyle.version>9.3</checkstyle.version>
         <fury.version>0.5.0</fury.version>
-        <javapoet.version>1.13.0</javapoet.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <logback.version>1.3.12</logback.version>
         <metainf-services.version>1.11</metainf-services.version>

--- a/test-support/test-support/pom.xml
+++ b/test-support/test-support/pom.xml
@@ -41,11 +41,6 @@
 
         <!-- external -->
         <dependency>
-            <groupId>com.thoughtworks.xstream</groupId>
-            <artifactId>xstream</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>net.automatalib</groupId>
             <artifactId>automata-api</artifactId>
         </dependency>
@@ -65,6 +60,10 @@
         <dependency>
             <groupId>org.checkerframework</groupId>
             <artifactId>checker-qual</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.furyio</groupId>
+            <artifactId>fury-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/test-support/test-support/pom.xml
+++ b/test-support/test-support/pom.xml
@@ -62,7 +62,7 @@
             <artifactId>checker-qual</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.furyio</groupId>
+            <groupId>org.apache.fury</groupId>
             <artifactId>fury-core</artifactId>
         </dependency>
         <dependency>

--- a/test-support/test-support/src/main/java/de/learnlib/testsupport/ResumeUtils.java
+++ b/test-support/test-support/src/main/java/de/learnlib/testsupport/ResumeUtils.java
@@ -15,21 +15,18 @@
  */
 package de.learnlib.testsupport;
 
-import java.nio.charset.StandardCharsets;
-
-import com.thoughtworks.xstream.XStream;
 import de.learnlib.Resumable;
+import io.fury.Fury;
 
 /**
  * Utility functions for {@link Resumable} features.
  */
 public final class ResumeUtils {
 
-    private static final XStream X_STREAM;
+    private static final Fury FURY;
 
     static {
-        X_STREAM = new XStream();
-        X_STREAM.allowTypesByRegExp(new String[] {"net.automatalib.*", "de.learnlib.*"});
+        FURY = Fury.builder().withRefTracking(true).requireClassRegistration(false).build();
     }
 
     private ResumeUtils() {
@@ -37,12 +34,12 @@ public final class ResumeUtils {
     }
 
     public static <T extends Object> byte[] toBytes(T state) {
-        return X_STREAM.toXML(state).getBytes(StandardCharsets.UTF_8);
+        return FURY.serialize(state);
     }
 
     @SuppressWarnings("unchecked")
     public static <T> T fromBytes(byte[] bytes) {
-        return (T) X_STREAM.fromXML(new String(bytes, StandardCharsets.UTF_8));
+        return (T) FURY.deserialize(bytes);
     }
 
 }

--- a/test-support/test-support/src/main/java/de/learnlib/testsupport/ResumeUtils.java
+++ b/test-support/test-support/src/main/java/de/learnlib/testsupport/ResumeUtils.java
@@ -17,6 +17,7 @@ package de.learnlib.testsupport;
 
 import de.learnlib.Resumable;
 import org.apache.fury.Fury;
+import org.apache.fury.logging.LoggerFactory;
 
 /**
  * Utility functions for {@link Resumable} features.
@@ -26,6 +27,7 @@ public final class ResumeUtils {
     private static final Fury FURY;
 
     static {
+        LoggerFactory.useSlf4jLogging(true);
         FURY = Fury.builder().withRefTracking(true).requireClassRegistration(false).build();
     }
 

--- a/test-support/test-support/src/main/java/de/learnlib/testsupport/ResumeUtils.java
+++ b/test-support/test-support/src/main/java/de/learnlib/testsupport/ResumeUtils.java
@@ -16,7 +16,7 @@
 package de.learnlib.testsupport;
 
 import de.learnlib.Resumable;
-import io.fury.Fury;
+import org.apache.fury.Fury;
 
 /**
  * Utility functions for {@link Resumable} features.

--- a/test-support/test-support/src/main/java/module-info.java
+++ b/test-support/test-support/src/main/java/module-info.java
@@ -35,13 +35,13 @@ open module de.learnlib.testsupport {
     requires de.learnlib.driver.simulator;
     requires de.learnlib.oracle.membership;
     requires de.learnlib.testsupport.example;
+    requires fury.core;
     requires net.automatalib.api;
     requires net.automatalib.common.util;
     requires net.automatalib.core;
     requires net.automatalib.util;
     requires org.mockito;
     requires org.testng;
-    requires xstream;
 
     // make non-static once https://github.com/typetools/checker-framework/issues/4559 is implemented
     requires static org.checkerframework.checker.qual;

--- a/test-support/test-support/src/main/java/module-info.java
+++ b/test-support/test-support/src/main/java/module-info.java
@@ -35,11 +35,11 @@ open module de.learnlib.testsupport {
     requires de.learnlib.driver.simulator;
     requires de.learnlib.oracle.membership;
     requires de.learnlib.testsupport.example;
-    requires fury.core;
     requires net.automatalib.api;
     requires net.automatalib.common.util;
     requires net.automatalib.core;
     requires net.automatalib.util;
+    requires org.apache.fury.core;
     requires org.mockito;
     requires org.testng;
 


### PR DESCRIPTION
Replaces the xstream serialization library with Apache Fury to get rid of unnecessary workaround profiles and JPMS warnings during compilation.