### PR TITLE
Bump minimal Java version to 11

### DIFF
--- a/algorithms/active/aaar/src/main/java/de/learnlib/algorithm/aaar/abstraction/AbstractAbstractionTree.java
+++ b/algorithms/active/aaar/src/main/java/de/learnlib/algorithm/aaar/abstraction/AbstractAbstractionTree.java
@@ -171,7 +171,7 @@ public abstract class AbstractAbstractionTree<AI, CI, D>
 
     @Override
     public VisualizationHelper<Node, Node> getVisualizationHelper() {
-        return new DefaultVisualizationHelper<Node, Node>() {
+        return new DefaultVisualizationHelper<>() {
 
             @Override
             public boolean getNodeProperties(Node node, Map<String, String> properties) {

--- a/algorithms/active/adt/src/main/java/de/learnlib/algorithm/adt/ads/DefensiveADS.java
+++ b/algorithms/active/adt/src/main/java/de/learnlib/algorithm/adt/ads/DefensiveADS.java
@@ -115,7 +115,7 @@ public final class DefensiveADS<S, I, O> {
         final Map<S, S> initialMapping = new ReflexiveMapView<>(states);
         Optional<ADTNode<S, I, O>> interMediateResult = compute(initialMapping);
 
-        while (!interMediateResult.isPresent()) {
+        while (interMediateResult.isEmpty()) {
 
             // we encountered open transitions that can be closed
             if (refinementStates != null && refinementInput != null) {
@@ -234,7 +234,7 @@ public final class DefensiveADS<S, I, O> {
                             succ = Optional.of(new ADTLeafNode<>(null, s));
                         }
 
-                        if (!succ.isPresent()) {
+                        if (succ.isEmpty()) {
                             cache.add(currentNodeAsBitSet);
                             continue oneSymbolFuture;
                         }

--- a/algorithms/active/adt/src/main/java/de/learnlib/algorithm/adt/adt/ADTNode.java
+++ b/algorithms/active/adt/src/main/java/de/learnlib/algorithm/adt/adt/ADTNode.java
@@ -55,7 +55,7 @@ public interface ADTNode<S, I, O> extends RecursiveADSNode<S, I, O, ADTNode<S, I
 
     @Override
     default VisualizationHelper<ADTNode<S, I, O>, ADTNode<S, I, O>> getVisualizationHelper() {
-        return new VisualizationHelper<ADTNode<S, I, O>, ADTNode<S, I, O>>() {
+        return new VisualizationHelper<>() {
 
             @Override
             public boolean getNodeProperties(ADTNode<S, I, O> node, Map<String, String> properties) {

--- a/algorithms/active/adt/src/main/java/de/learnlib/algorithm/adt/config/model/extender/DefaultExtender.java
+++ b/algorithms/active/adt/src/main/java/de/learnlib/algorithm/adt/config/model/extender/DefaultExtender.java
@@ -115,7 +115,7 @@ public class DefaultExtender implements ADTExtender {
                                                                                                          currentSet,
                                                                                                          partialTransitionAnalyzer);
 
-                if (!potentialExtension.isPresent()) {
+                if (potentialExtension.isEmpty()) {
                     return ExtensionResult.empty();
                 }
 

--- a/algorithms/active/adt/src/main/java/module-info.java
+++ b/algorithms/active/adt/src/main/java/module-info.java
@@ -50,6 +50,10 @@ open module de.learnlib.algorithm.adt {
     exports de.learnlib.algorithm.adt.api;
     exports de.learnlib.algorithm.adt.automaton;
     exports de.learnlib.algorithm.adt.config;
+    exports de.learnlib.algorithm.adt.config.model;
+    exports de.learnlib.algorithm.adt.config.model.calculator;
+    exports de.learnlib.algorithm.adt.config.model.extender;
+    exports de.learnlib.algorithm.adt.config.model.replacer;
     exports de.learnlib.algorithm.adt.learner;
     exports de.learnlib.algorithm.adt.model;
     exports de.learnlib.algorithm.adt.util;

--- a/algorithms/active/lsharp/src/main/java/de/learnlib/algorithm/lsharp/ads/ArenaNode.java
+++ b/algorithms/active/lsharp/src/main/java/de/learnlib/algorithm/lsharp/ads/ArenaNode.java
@@ -21,7 +21,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class ArenaNode<T, P> {
 
     public final @Nullable Pair<P, Integer> parent;
-    public T value;
+    public final T value;
 
     public ArenaNode(@Nullable Pair<P, Integer> parent, T value) {
         this.parent = parent;

--- a/algorithms/active/lstar/src/main/java/de/learnlib/algorithm/lstar/ce/ObservationTableCEXHandlers.java
+++ b/algorithms/active/lstar/src/main/java/de/learnlib/algorithm/lstar/ce/ObservationTableCEXHandlers.java
@@ -142,7 +142,7 @@ public final class ObservationTableCEXHandlers {
 
     public static <I, D> ObservationTableCEXHandler<I, D> fromLocalSuffixFinder(LocalSuffixFinder<I, D> localFinder,
                                                                                 boolean allSuffixes) {
-        return new ObservationTableCEXHandler<I, D>() {
+        return new ObservationTableCEXHandler<>() {
 
             @Override
             public <RI extends I, RD extends D> List<List<Row<RI>>> handleCounterexample(DefaultQuery<RI, RD> ceQuery,

--- a/algorithms/active/lstar/src/main/java/de/learnlib/algorithm/lstar/ce/ObservationTableCEXHandlers.java
+++ b/algorithms/active/lstar/src/main/java/de/learnlib/algorithm/lstar/ce/ObservationTableCEXHandlers.java
@@ -34,7 +34,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class ObservationTableCEXHandlers {
 
     public static final ObservationTableCEXHandler<@Nullable Object, @Nullable Object> CLASSIC_LSTAR =
-            new ObservationTableCEXHandler<@Nullable Object, @Nullable Object>() {
+            new ObservationTableCEXHandler<>() {
 
                 @Override
                 public <RI, RD> List<List<Row<RI>>> handleCounterexample(DefaultQuery<RI, RD> ceQuery,
@@ -57,7 +57,7 @@ public final class ObservationTableCEXHandlers {
             };
 
     public static final ObservationTableCEXHandler<@Nullable Object, @Nullable Object> SUFFIX1BY1 =
-            new ObservationTableCEXHandler<@Nullable Object, @Nullable Object>() {
+            new ObservationTableCEXHandler<>() {
 
                 @Override
                 public <RI, RD> List<List<Row<RI>>> handleCounterexample(DefaultQuery<RI, RD> ceQuery,
@@ -107,7 +107,7 @@ public final class ObservationTableCEXHandlers {
     }
 
     public static <I, D> ObservationTableCEXHandler<I, D> fromGlobalSuffixFinder(GlobalSuffixFinder<I, D> globalFinder) {
-        return new ObservationTableCEXHandler<I, D>() {
+        return new ObservationTableCEXHandler<>() {
 
             @Override
             public <RI extends I, RD extends D> List<List<Row<RI>>> handleCounterexample(DefaultQuery<RI, RD> ceQuery,

--- a/algorithms/active/lstar/src/main/java/de/learnlib/algorithm/lstar/closing/ClosingStrategies.java
+++ b/algorithms/active/lstar/src/main/java/de/learnlib/algorithm/lstar/closing/ClosingStrategies.java
@@ -41,7 +41,7 @@ public final class ClosingStrategies {
      * Closing strategy that selects the first row from each equivalence class as representative.
      */
     public static final ClosingStrategy<@Nullable Object, @Nullable Object> CLOSE_FIRST =
-            new ClosingStrategy<@Nullable Object, @Nullable Object>() {
+            new ClosingStrategy<>() {
 
                 @Override
                 public <RI, RD> List<Row<RI>> selectClosingRows(List<List<Row<RI>>> unclosedClasses,
@@ -65,7 +65,7 @@ public final class ClosingStrategies {
      * has minimal length in the respective class) as representative.
      */
     public static final ClosingStrategy<@Nullable Object, @Nullable Object> CLOSE_SHORTEST =
-            new ClosingStrategy<@Nullable Object, @Nullable Object>() {
+            new ClosingStrategy<>() {
 
                 @Override
                 public <RI, RD> List<Row<RI>> selectClosingRows(List<List<Row<RI>>> unclosedClasses,
@@ -100,7 +100,7 @@ public final class ClosingStrategies {
      * representative.
      */
     public static final ClosingStrategy<@Nullable Object, @Nullable Object> CLOSE_LEX_MIN =
-            new ClosingStrategy<@Nullable Object, @Nullable Object>() {
+            new ClosingStrategy<>() {
 
                 @Override
                 public <RI, RD> List<Row<RI>> selectClosingRows(List<List<Row<RI>>> unclosedClasses,

--- a/algorithms/active/observation-pack/src/main/java/de/learnlib/algorithm/observationpack/dfa/OPLearnerDFA.java
+++ b/algorithms/active/observation-pack/src/main/java/de/learnlib/algorithm/observationpack/dfa/OPLearnerDFA.java
@@ -69,7 +69,7 @@ public class OPLearnerDFA<I> extends AbstractOPLearner<DFA<?, I>, I, Boolean, Bo
 
     @Override
     protected Query<I, Boolean> spQuery(HState<I, Boolean, Boolean, Void> state) {
-        return new AbstractQuery<I, Boolean>(state.getAccessSequence(), Word.epsilon()) {
+        return new AbstractQuery<>(state.getAccessSequence(), Word.epsilon()) {
 
             @Override
             public void answer(Boolean val) {

--- a/algorithms/active/observation-pack/src/main/java/de/learnlib/algorithm/observationpack/hypothesis/OPLearnerHypothesis.java
+++ b/algorithms/active/observation-pack/src/main/java/de/learnlib/algorithm/observationpack/hypothesis/OPLearnerHypothesis.java
@@ -204,7 +204,7 @@ public class OPLearnerHypothesis<I, O, SP, TP>
 
         @Override
         public VisualizationHelper<HState<I, O, SP, TP>, HTransition<I, O, SP, TP>> getVisualizationHelper() {
-            return new DefaultVisualizationHelper<HState<I, O, SP, TP>, HTransition<I, O, SP, TP>>() {
+            return new DefaultVisualizationHelper<>() {
 
                 @Override
                 protected Collection<HState<I, O, SP, TP>> initialNodes() {

--- a/algorithms/active/observation-pack/src/main/java/de/learnlib/algorithm/observationpack/mealy/OPLearnerMealy.java
+++ b/algorithms/active/observation-pack/src/main/java/de/learnlib/algorithm/observationpack/mealy/OPLearnerMealy.java
@@ -73,8 +73,8 @@ public class OPLearnerMealy<I, O> extends AbstractOPLearner<MealyMachine<?, I, ?
 
     @Override
     protected Query<I, Word<O>> tpQuery(HTransition<I, Word<O>, Void, O> transition) {
-        return new AbstractQuery<I, Word<O>>(transition.getSource().getAccessSequence(),
-                                             Word.fromLetter(transition.getSymbol())) {
+        return new AbstractQuery<>(transition.getSource().getAccessSequence(),
+                                   Word.fromLetter(transition.getSymbol())) {
 
             @Override
             public void answer(Word<O> output) {

--- a/algorithms/active/observation-pack/src/main/java/de/learnlib/algorithm/observationpack/moore/OPLearnerMoore.java
+++ b/algorithms/active/observation-pack/src/main/java/de/learnlib/algorithm/observationpack/moore/OPLearnerMoore.java
@@ -51,7 +51,7 @@ public class OPLearnerMoore<I, O> extends AbstractOPLearner<MooreMachine<?, I, ?
 
     @Override
     protected @Nullable Query<I, Word<O>> spQuery(HState<I, Word<O>, O, Void> state) {
-        return new AbstractQuery<I, Word<O>>(state.getAccessSequence(), Word.epsilon()) {
+        return new AbstractQuery<>(state.getAccessSequence(), Word.epsilon()) {
 
             @Override
             public void answer(Word<O> output) {

--- a/algorithms/active/ttt/src/main/java/de/learnlib/algorithm/ttt/base/AbstractTTTHypothesis.java
+++ b/algorithms/active/ttt/src/main/java/de/learnlib/algorithm/ttt/base/AbstractTTTHypothesis.java
@@ -254,7 +254,7 @@ public abstract class AbstractTTTHypothesis<S extends TTTState<I, D>, I, D, T>
 
         @Override
         public VisualizationHelper<TTTState<I, D>, TTTEdge<I, D>> getVisualizationHelper() {
-            return new DefaultVisualizationHelper<TTTState<I, D>, TTTEdge<I, D>>() {
+            return new DefaultVisualizationHelper<>() {
 
                 @Override
                 public boolean getEdgeProperties(TTTState<I, D> src,

--- a/algorithms/active/ttt/src/main/java/de/learnlib/algorithm/ttt/base/BaseTTTDiscriminationTree.java
+++ b/algorithms/active/ttt/src/main/java/de/learnlib/algorithm/ttt/base/BaseTTTDiscriminationTree.java
@@ -92,7 +92,7 @@ public class BaseTTTDiscriminationTree<I, D>
 
     @Override
     public VisualizationHelper<AbstractBaseDTNode<I, D>, Entry<D, AbstractBaseDTNode<I, D>>> getVisualizationHelper() {
-        return new VisualizationHelper<AbstractBaseDTNode<I, D>, Entry<D, AbstractBaseDTNode<I, D>>>() {
+        return new VisualizationHelper<>() {
 
             @Override
             public boolean getNodeProperties(AbstractBaseDTNode<I, D> node, Map<String, String> properties) {

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -213,17 +213,10 @@ limitations under the License.
                                     <goal>compile</goal>
                                 </goals>
                                 <configuration>
-                                    <release>11</release>
                                     <failOnWarning>true</failOnWarning>
                                     <fork>true</fork>
-                                    <!--
-                                     Setting a different output directly can fail the build when using other annotation
-                                     processors as well. However, with using the same output directory, we pack Java 11
-                                     code in the jars which will fail other analysis tools. Currently, checkerframework
-                                     cannot be run with our other analysis steps...
-                                     -->
-                                    <!--outputDirectory>${project.build.directory}/checkerframework</outputDirectory-->
-                                    <annotationProcessorPaths>
+                                    <outputDirectory>${project.build.directory}/checkerframework</outputDirectory>
+                                    <annotationProcessorPaths combine.children="append">
                                         <path>
                                             <groupId>org.checkerframework</groupId>
                                             <artifactId>checker</artifactId>
@@ -232,6 +225,9 @@ limitations under the License.
                                     </annotationProcessorPaths>
                                     <annotationProcessors>
                                         <annotationProcessor>org.checkerframework.checker.nullness.NullnessChecker</annotationProcessor>
+                                        <!-- by having to explicitly list the CF checkers, we also need to list otherwise automatically picked-up processors -->
+                                        <annotationProcessor>de.learnlib.tooling.processor.builder.BuilderProcessor</annotationProcessor>
+                                        <annotationProcessor>de.learnlib.tooling.processor.refinement.RefinementProcessor</annotationProcessor>
                                     </annotationProcessors>
                                     <compilerArgs>
                                         <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>

--- a/commons/counterexamples/src/main/java/de/learnlib/counterexample/GlobalSuffixFinders.java
+++ b/commons/counterexamples/src/main/java/de/learnlib/counterexample/GlobalSuffixFinders.java
@@ -172,7 +172,7 @@ public final class GlobalSuffixFinders {
     public static <I, D> GlobalSuffixFinder<I, D> fromLocalFinder(LocalSuffixFinder<I, D> localFinder,
                                                                   boolean allSuffixes) {
 
-        return new GlobalSuffixFinder<I, D>() {
+        return new GlobalSuffixFinder<>() {
 
             @Override
             public <RI extends I, RD extends D> List<Word<RI>> findSuffixes(Query<RI, RD> ceQuery,

--- a/commons/counterexamples/src/main/java/de/learnlib/counterexample/GlobalSuffixFinders.java
+++ b/commons/counterexamples/src/main/java/de/learnlib/counterexample/GlobalSuffixFinders.java
@@ -38,7 +38,7 @@ public final class GlobalSuffixFinders {
      * @see #findMalerPnueli(Query)
      */
     public static final GlobalSuffixFinder<@Nullable Object, @Nullable Object> MALER_PNUELI =
-            new GlobalSuffixFinder<@Nullable Object, @Nullable Object>() {
+            new GlobalSuffixFinder<>() {
 
                 @Override
                 public <RI, RD> List<Word<RI>> findSuffixes(Query<RI, RD> ceQuery,
@@ -61,7 +61,7 @@ public final class GlobalSuffixFinders {
      * @see #findShahbaz(Query, AccessSequenceTransformer)
      */
     public static final GlobalSuffixFinder<@Nullable Object, @Nullable Object> SHAHBAZ =
-            new GlobalSuffixFinder<@Nullable Object, @Nullable Object>() {
+            new GlobalSuffixFinder<>() {
 
                 @Override
                 public <RI, RD> List<Word<RI>> findSuffixes(Query<RI, RD> ceQuery,

--- a/commons/datastructures/src/main/java/de/learnlib/datastructure/discriminationtree/model/AbstractDiscriminationTree.java
+++ b/commons/datastructures/src/main/java/de/learnlib/datastructure/discriminationtree/model/AbstractDiscriminationTree.java
@@ -257,7 +257,7 @@ public abstract class AbstractDiscriminationTree<DSCR, I, O, D, N extends Abstra
 
     @Override
     public VisualizationHelper<N, Entry<O, N>> getVisualizationHelper() {
-        return new DefaultVisualizationHelper<N, Entry<O, N>>() {
+        return new DefaultVisualizationHelper<>() {
 
             @Override
             public boolean getNodeProperties(N node, Map<String, String> properties) {

--- a/commons/datastructures/src/main/java/de/learnlib/datastructure/pta/BasePTA.java
+++ b/commons/datastructures/src/main/java/de/learnlib/datastructure/pta/BasePTA.java
@@ -179,7 +179,7 @@ public class BasePTA<S extends AbstractBasePTAState<S, SP, TP>, SP, TP>
         bfsQueue.add(root);
         visited.add(root);
 
-        return new AbstractSimplifiedIterator<S>() {
+        return new AbstractSimplifiedIterator<>() {
 
             @Override
             protected boolean calculateNext() {
@@ -250,7 +250,7 @@ public class BasePTA<S extends AbstractBasePTAState<S, SP, TP>, SP, TP>
     @Override
     public UniversalGraph<S, TransitionEdge<Integer, PTATransition<S>>, SP, Property<Integer, TP>> transitionGraphView(
             Collection<? extends Integer> inputs) {
-        return new UniversalAutomatonGraphView<S, Integer, PTATransition<S>, SP, TP, BasePTA<S, SP, TP>>(this, inputs) {
+        return new UniversalAutomatonGraphView<>(this, inputs) {
 
             @Override
             public VisualizationHelper<S, TransitionEdge<Integer, PTATransition<S>>> getVisualizationHelper() {

--- a/commons/datastructures/src/test/java/de/learnlib/datastructure/observationtable/writer/ObservationTableWriterTest.java
+++ b/commons/datastructures/src/test/java/de/learnlib/datastructure/observationtable/writer/ObservationTableWriterTest.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
@@ -58,8 +57,7 @@ public class ObservationTableWriterTest {
 
         final URL resource = ObservationTableWriterTest.class.getResource(urlOfExpectedResult);
         Assert.assertNotNull(resource);
-        final String expectedResult =
-                new String(Files.readAllBytes(Paths.get(resource.toURI())), StandardCharsets.UTF_8);
+        final String expectedResult = Files.readString(Paths.get(resource.toURI()));
 
         Assert.assertEquals(writerResult.toString(), expectedResult);
     }

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -556,6 +556,12 @@ limitations under the License.
                             <finalName>learnlib-${project.version}</finalName>
                             <jarOutputDirectory>${project.build.directory}/bundles</jarOutputDirectory>
                             <includeDependencySources>true</includeDependencySources>
+                            <!-- Aggregating multiple module-info,javas causes problems -->
+                            <legacyMode>true</legacyMode>
+                            <disableSourcepathUsage>true</disableSourcepathUsage>
+                            <sourceFileExcludes>
+                                <sourceFileExclude>**/module-info.java</sourceFileExclude>
+                            </sourceFileExcludes>
                             <dependencySourceIncludes>
                                 <dependencySourceInclude>de.learnlib:*</dependencySourceInclude>
                             </dependencySourceIncludes>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -556,7 +556,7 @@ limitations under the License.
                             <finalName>learnlib-${project.version}</finalName>
                             <jarOutputDirectory>${project.build.directory}/bundles</jarOutputDirectory>
                             <includeDependencySources>true</includeDependencySources>
-                            <!-- Aggregating multiple module-info,javas causes problems -->
+                            <!-- Aggregating multiple module-info.javas causes problems -->
                             <legacyMode>true</legacyMode>
                             <disableSourcepathUsage>true</disableSourcepathUsage>
                             <sourceFileExcludes>

--- a/filters/cache/src/test/java/de/learnlib/filter/cache/CacheConfig.java
+++ b/filters/cache/src/test/java/de/learnlib/filter/cache/CacheConfig.java
@@ -59,7 +59,7 @@ public interface CacheConfig<I, D, C extends LearningCache<?, I, D>> {
         @Override
         public CacheConfig<I, D, C> apply(Alphabet<I> alphabet, M oracle) {
 
-            return new CacheConfig<I, D, C>() {
+            return new CacheConfig<>() {
 
                 final Supplier<C> transformedSupplier;
 
@@ -115,7 +115,7 @@ public interface CacheConfig<I, D, C extends LearningCache<?, I, D>> {
         @Override
         public CacheConfig<I, Word<O>, C> apply(Alphabet<I> alphabet, SUL<I, O> sul) {
 
-            return new CacheConfig<I, Word<O>, C>() {
+            return new CacheConfig<>() {
 
                 final C cache;
 
@@ -148,7 +148,7 @@ public interface CacheConfig<I, D, C extends LearningCache<?, I, D>> {
         @Override
         public CacheConfig<I, Word<O>, C> apply(Alphabet<I> alphabet, StateLocalInputSUL<I, O> sul) {
 
-            return new CacheConfig<I, Word<O>, C>() {
+            return new CacheConfig<>() {
 
                 final C cache;
 
@@ -183,7 +183,7 @@ public interface CacheConfig<I, D, C extends LearningCache<?, I, D>> {
         @Override
         public CacheConfig<I, D, C> apply(Alphabet<I> alphabet, M oracle) {
 
-            return new CacheConfig<I, D, C>() {
+            return new CacheConfig<>() {
 
                 final List<C> oracles;
 

--- a/filters/reuse/src/test/java/de/learnlib/filter/reuse/test/DomainKnowledgeTest.java
+++ b/filters/reuse/src/test/java/de/learnlib/filter/reuse/test/DomainKnowledgeTest.java
@@ -115,7 +115,7 @@ public class DomainKnowledgeTest {
 
         @Override
         public ReuseCapableOracle<Integer, Integer, String> get() {
-            return new ReuseCapableOracle<Integer, Integer, String>() {
+            return new ReuseCapableOracle<>() {
 
                 @Override
                 public QueryResult<Integer, String> continueQuery(Word<Integer> trace, Integer integer) {

--- a/filters/reuse/src/test/java/de/learnlib/filter/reuse/test/ReuseOracleTest.java
+++ b/filters/reuse/src/test/java/de/learnlib/filter/reuse/test/ReuseOracleTest.java
@@ -40,7 +40,7 @@ public class ReuseOracleTest {
     protected void setUp() {
         // We don't use this oracle, we directly test against the reuse tree!
         final ReuseCapableOracle<Integer, Integer, String> reuseCapableOracle =
-                new ReuseCapableOracle<Integer, Integer, String>() {
+                new ReuseCapableOracle<>() {
 
                     @Override
                     public QueryResult<Integer, String> continueQuery(Word<Integer> trace, Integer s) {

--- a/pom.xml
+++ b/pom.xml
@@ -213,12 +213,9 @@ limitations under the License.
         <!-- general config -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.release>8</maven.compiler.release>
-        <maven.compiler.testSource>11</maven.compiler.testSource>
-        <maven.compiler.testTarget>11</maven.compiler.testTarget>
-        <maven.compiler.testRelease>11</maven.compiler.testRelease>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
         <argLine /> <!-- compatibility for property expansion in surefire-plugin -->
 
         <!-- plugin versions -->
@@ -227,7 +224,7 @@ limitations under the License.
         <assembly-plugin.version>3.7.1</assembly-plugin.version>
         <checkstyle-plugin.version>3.6.0</checkstyle-plugin.version>
         <clean-plugin.version>3.4.0</clean-plugin.version>
-        <compiler-plugin.version>3.11.0</compiler-plugin.version> <!-- changes to incremental compilation causes issues with our two compile phases. bump, once we completely switch to Java 11 -->
+        <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <coveralls-plugin.version>4.3.0</coveralls-plugin.version>
         <dependency-plugin.version>3.8.1</dependency-plugin.version>
         <deploy-plugin.version>3.1.3</deploy-plugin.version>
@@ -868,37 +865,6 @@ limitations under the License.
                             </path>
                         </annotationProcessorPaths>
                     </configuration>
-                    <executions>
-                        <execution>
-                            <id>default-compile</id>
-                            <goals>
-                                <goal>compile</goal>
-                            </goals>
-                            <configuration>
-                                <!-- compile everything in module-aware mode to check for errors -->
-                                <release>9</release>
-                                <createMissingPackageInfoClass>false</createMissingPackageInfoClass>
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <id>java-8-compile</id>
-                            <goals>
-                                <goal>compile</goal>
-                            </goals>
-                            <configuration>
-                                <!-- recompile generated sources as well -->
-                                <compileSourceRoots>
-                                    <compileSourceRoot>${project.build.sourceDirectory}</compileSourceRoot>
-                                    <compileSourceRoot>${project.build.directory}/generated-sources</compileSourceRoot>
-                                </compileSourceRoots>
-                                <proc>none</proc>
-                                <!-- re-compile everything for target VM except the module-info.java -->
-                                <excludes>
-                                    <exclude>module-info.java</exclude>
-                                </excludes>
-                            </configuration>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -966,9 +932,6 @@ limitations under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <release>11</release>
-                </configuration>
                 <reportSets>
                     <reportSet>
                         <id>non-aggregate</id>

--- a/test-support/pom.xml
+++ b/test-support/pom.xml
@@ -51,35 +51,4 @@ limitations under the License.
             </plugins>
         </pluginManagement>
     </build>
-
-    <profiles>
-        <profile>
-            <id>code-analysis</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-enforcer-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>enforce-bytecode-version</id>
-                                <configuration>
-                                    <rules>
-                                        <enforceBytecodeVersion>
-                                            <!--
-                                            while we somewhat break our contract, this module is only intended for
-                                            testing, so we are a little less restrictive for (JDK) compatibility reasons
-                                            -->
-                                            <maxJdkVersion>${maven.compiler.testTarget}</maxJdkVersion>
-                                        </enforceBytecodeVersion>
-                                    </rules>
-                                    <fail>true</fail>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
There does not seem to be a need for supporting Java 8 anymore, so simplify our build process and benefit from some language goodies.