### PR TITLE
Bump Java Version to 17/25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: "Tests and Analysis (JDK: ${{ matrix.jdk }})"
     strategy:
       matrix:
-        jdk: [ 11, 17, 21 ]
+        jdk: [ 17, 21, 25 ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -56,7 +56,7 @@ jobs:
     needs: [ tests-and-analysis ]
     strategy:
       matrix:
-        jdk: [ 11, 17, 21 ]
+        jdk: [ 17, 21, 25 ]
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -99,7 +99,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
       - name: Set up cache
         uses: actions/cache@v3
         with:
@@ -150,7 +150,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
       - name: Set up cache
         uses: actions/cache@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-* LearnLib now requires Java 11 at runtime.
+* LearnLib now requires Java 17 at runtime.
 * The `generateTestWords` method of `AbstractTestWordEQOracle` now needs to be public.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Contributions -- whether it is in the form of new features, better documentation
 
 For simply using LearnLib you may use the Maven artifacts which are available in the [Maven Central repository][maven-central].
 It is also possible to download a bundled [distribution artifact][maven-central-distr] if you want to use LearnLib without Maven support.
-Note that LearnLib requires Java 17 (or newer) to build but still supports Java 11 at runtime.
+Note that LearnLib requires Java 17 (or newer) to build and run.
 
 #### Building development versions
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Contributions -- whether it is in the form of new features, better documentation
 
 For simply using LearnLib you may use the Maven artifacts which are available in the [Maven Central repository][maven-central].
 It is also possible to download a bundled [distribution artifact][maven-central-distr] if you want to use LearnLib without Maven support.
-Note that LearnLib requires Java 11 (or newer) to build but still supports Java 8 at runtime.
+Note that LearnLib requires Java 17 (or newer) to build but still supports Java 11 at runtime.
 
 #### Building development versions
 

--- a/algorithms/active/aaar/src/main/java/de/learnlib/algorithm/aaar/abstraction/AbstractAbstractionTree.java
+++ b/algorithms/active/aaar/src/main/java/de/learnlib/algorithm/aaar/abstraction/AbstractAbstractionTree.java
@@ -132,8 +132,7 @@ public abstract class AbstractAbstractionTree<AI, CI, D>
 
     @Override
     public Collection<Node> getOutgoingEdges(Node node) {
-        if (node instanceof InnerNode) {
-            final InnerNode<?, ?> n = (InnerNode<?, ?>) node;
+        if (node instanceof InnerNode<?, ?> n) {
             return Arrays.asList(n.equalsNext, n.otherNext);
         }
 
@@ -155,8 +154,7 @@ public abstract class AbstractAbstractionTree<AI, CI, D>
 
         while (!nodes.isEmpty()) {
             final Node n = nodes.poll();
-            if (n instanceof InnerNode) {
-                final InnerNode<?, ?> in = (InnerNode<?, ?>) n;
+            if (n instanceof InnerNode<?, ?> in) {
                 result.add(in);
                 nodes.add(in.equalsNext);
                 nodes.add(in.otherNext);
@@ -177,11 +175,9 @@ public abstract class AbstractAbstractionTree<AI, CI, D>
             public boolean getNodeProperties(Node node, Map<String, String> properties) {
                 super.getNodeProperties(node, properties);
 
-                if (node instanceof InnerNode) {
-                    final InnerNode<?, ?> n = (InnerNode<?, ?>) node;
+                if (node instanceof InnerNode<?, ?> n) {
                     properties.put(NodeAttrs.LABEL, n.prefix + ", " + n.suffix);
-                } else if (node instanceof Leaf) {
-                    final Leaf<?, ?> l = (Leaf<?, ?>) node;
+                } else if (node instanceof Leaf<?, ?> l) {
                     properties.put(NodeAttrs.LABEL, String.format("Abs.: '%s'%nRep.: '%s'", l.abs, l.rep));
                 }
 
@@ -192,8 +188,7 @@ public abstract class AbstractAbstractionTree<AI, CI, D>
             public boolean getEdgeProperties(Node src, Node edge, Node tgt, Map<String, String> properties) {
                 super.getEdgeProperties(src, edge, tgt, properties);
 
-                if (src instanceof InnerNode) {
-                    final InnerNode<?, ?> n = (InnerNode<?, ?>) src;
+                if (src instanceof InnerNode<?, ?> n) {
                     if (n.equalsNext == tgt) {
                         properties.put(EdgeAttrs.LABEL, "== " + n.out);
                     } else {

--- a/algorithms/active/aaar/src/main/java/de/learnlib/algorithm/aaar/abstraction/Node.java
+++ b/algorithms/active/aaar/src/main/java/de/learnlib/algorithm/aaar/abstraction/Node.java
@@ -17,7 +17,7 @@ package de.learnlib.algorithm.aaar.abstraction;
 
 import net.automatalib.word.Word;
 
-class Node {
+public class Node {
 
     static class InnerNode<CI, D> extends Node {
 

--- a/algorithms/active/aaar/src/test/java/de/learnlib/algorithm/aaar/explicit/ModuloInitialAbstraction.java
+++ b/algorithms/active/aaar/src/test/java/de/learnlib/algorithm/aaar/explicit/ModuloInitialAbstraction.java
@@ -40,14 +40,11 @@ public class ModuloInitialAbstraction<CI> implements ExplicitInitialAbstraction<
 
     @Override
     public CI getRepresentative(String a) {
-        switch (a) {
-            case "even":
-                return alphabet.getSymbol(0);
-            case "odd":
-                return alphabet.getSymbol(1);
-            default:
-                throw new IllegalArgumentException("Unknown symbol: " + a);
-        }
+        return switch (a) {
+            case "even" -> alphabet.getSymbol(0);
+            case "odd" -> alphabet.getSymbol(1);
+            default -> throw new IllegalArgumentException("Unknown symbol: " + a);
+        };
     }
 
     @Override

--- a/algorithms/active/adt/src/main/java/de/learnlib/algorithm/adt/api/ADTExtender.java
+++ b/algorithms/active/adt/src/main/java/de/learnlib/algorithm/adt/api/ADTExtender.java
@@ -24,6 +24,7 @@ import de.learnlib.algorithm.adt.model.ExtensionResult;
  * Interface for configuration objects that specify how to finalize the temporary splitter given by regular
  * counterexample decomposition.
  */
+@FunctionalInterface
 public interface ADTExtender {
 
     /**

--- a/algorithms/active/adt/src/main/java/de/learnlib/algorithm/adt/api/LeafSplitter.java
+++ b/algorithms/active/adt/src/main/java/de/learnlib/algorithm/adt/api/LeafSplitter.java
@@ -22,6 +22,7 @@ import net.automatalib.word.Word;
  * Interface for configuration objects that specify how to split the ADT leaf of a hypothesis state that needs
  * refinement.
  */
+@FunctionalInterface
 public interface LeafSplitter {
 
     /**

--- a/algorithms/active/adt/src/main/java/de/learnlib/algorithm/adt/api/SubtreeReplacer.java
+++ b/algorithms/active/adt/src/main/java/de/learnlib/algorithm/adt/api/SubtreeReplacer.java
@@ -25,6 +25,7 @@ import net.automatalib.automaton.transducer.MealyMachine;
 /**
  * Interface for configuration objects that specify how nodes of the current ADT should be replaced.
  */
+@FunctionalInterface
 public interface SubtreeReplacer {
 
     /**

--- a/algorithms/active/adt/src/main/java/de/learnlib/algorithm/adt/config/model/ADSCalculator.java
+++ b/algorithms/active/adt/src/main/java/de/learnlib/algorithm/adt/config/model/ADSCalculator.java
@@ -22,6 +22,7 @@ import de.learnlib.algorithm.adt.adt.ADTNode;
 import net.automatalib.alphabet.Alphabet;
 import net.automatalib.automaton.transducer.MealyMachine;
 
+@FunctionalInterface
 public interface ADSCalculator {
 
     <S, I, O> Optional<ADTNode<S, I, O>> compute(MealyMachine<S, I, ?, O> hypothesis,

--- a/algorithms/active/adt/src/main/java/de/learnlib/algorithm/adt/config/model/DefensiveADSCalculator.java
+++ b/algorithms/active/adt/src/main/java/de/learnlib/algorithm/adt/config/model/DefensiveADSCalculator.java
@@ -23,6 +23,7 @@ import de.learnlib.algorithm.adt.api.PartialTransitionAnalyzer;
 import net.automatalib.alphabet.Alphabet;
 import net.automatalib.automaton.transducer.MealyMachine;
 
+@FunctionalInterface
 public interface DefensiveADSCalculator {
 
     <S, I, O> Optional<ADTNode<S, I, O>> compute(MealyMachine<S, I, ?, O> automaton,

--- a/algorithms/active/kearns-vazirani/src/main/java/de/learnlib/algorithm/kv/dfa/KearnsVaziraniDFA.java
+++ b/algorithms/active/kearns-vazirani/src/main/java/de/learnlib/algorithm/kv/dfa/KearnsVaziraniDFA.java
@@ -186,9 +186,7 @@ public class KearnsVaziraniDFA<I>
 
         final List<Word<I>> transAs = new ArrayList<>(numTrans);
 
-        for (int i = 0; i < numTrans; i++) {
-            long encodedTrans = transList.get(i);
-
+        for (long encodedTrans : transList) {
             int sourceState = (int) (encodedTrans >> Integer.SIZE);
             int transIdx = (int) encodedTrans;
 

--- a/algorithms/active/kearns-vazirani/src/main/java/de/learnlib/algorithm/kv/mealy/KearnsVaziraniMealy.java
+++ b/algorithms/active/kearns-vazirani/src/main/java/de/learnlib/algorithm/kv/mealy/KearnsVaziraniMealy.java
@@ -198,9 +198,7 @@ public class KearnsVaziraniMealy<I, O>
 
         final List<Word<I>> transAs = new ArrayList<>(numTrans);
 
-        for (int i = 0; i < numTrans; i++) {
-            long encodedTrans = transList.get(i);
-
+        for (long encodedTrans : transList) {
             int sourceState = (int) (encodedTrans >> Integer.SIZE);
             int transIdx = (int) encodedTrans;
 

--- a/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/dt/DTLeaf.java
+++ b/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/dt/DTLeaf.java
@@ -111,8 +111,8 @@ public class DTLeaf<I, D> extends AbstractDTNode<I, D> {
         DTLeaf<I, D> ua2 = s2.state();
         AbstractDTNode<I, D> n = lca(ua1, ua2);
         STNode<I> av;
-        if (n instanceof DTInnerNode) {
-            av = ((DTInnerNode<I, D>) n).suffix().prepend(a);
+        if (n instanceof DTInnerNode<I, D> in) {
+            av = in.suffix().prepend(a);
         } else {
             av = tree.newSuffix(a);
         }

--- a/algorithms/active/lsharp/src/main/java/de/learnlib/algorithm/lsharp/LSOracle.java
+++ b/algorithms/active/lsharp/src/main/java/de/learnlib/algorithm/lsharp/LSOracle.java
@@ -78,6 +78,7 @@ public class LSOracle<I, O> {
         return shuffled.subList(0, 2);
     }
 
+    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     private Pair<Word<I>, Word<O>> rule3IO(List<Word<I>> candidates, Word<I> prefix) {
         switch (this.rule3) {
             case ADS:
@@ -147,6 +148,7 @@ public class LSOracle<I, O> {
         return candidates;
     }
 
+    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     private Pair<Word<I>, Word<O>> rule2IO(Word<I> accessQ, I i, List<Integer> bss, Collection<Word<I>> basis) {
         switch (this.rule2) {
             case ADS:

--- a/algorithms/active/lsharp/src/main/java/de/learnlib/algorithm/lsharp/LSOracle.java
+++ b/algorithms/active/lsharp/src/main/java/de/learnlib/algorithm/lsharp/LSOracle.java
@@ -78,9 +78,9 @@ public class LSOracle<I, O> {
         return shuffled.subList(0, 2);
     }
 
-    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
+    @SuppressWarnings("PMD.SwitchDensity")
     private Pair<Word<I>, Word<O>> rule3IO(List<Word<I>> candidates, Word<I> prefix) {
-        switch (this.rule3) {
+        return switch (this.rule3) {
             case ADS:
                 if (candidates.size() == 2) {
                     Word<I> q1Acc = candidates.get(0);
@@ -93,28 +93,25 @@ public class LSOracle<I, O> {
                     Word<I> wit = ApartnessUtil.computeWitness(obsTree, q1, q2);
                     assert wit != null;
 
-                    WordBuilder<I> inputSeq = new WordBuilder<>(prefix);
                     assert !(ApartnessUtil.accStatesAreApart(obsTree, prefix, q1Acc) ||
                              ApartnessUtil.accStatesAreApart(obsTree, prefix, q2Acc));
-                    inputSeq.append(wit);
-                    Word<O> outputSeq = this.outputQuery(inputSeq.toWord());
 
-                    return Pair.of(inputSeq.toWord(), outputSeq);
+                    Word<I> inputSeq = prefix.concat(wit);
+                    Word<O> outputSeq = this.outputQuery(inputSeq);
 
+                    yield Pair.of(inputSeq, outputSeq);
                 } else {
                     List<Integer> candss = getSuccs(candidates);
                     ADSTree<Integer, I, O> suffix = new ADSTree<>(obsTree, candss, sinkOutput);
-                    return this.adaptiveOutputQuery(prefix, null, suffix);
+                    yield this.adaptiveOutputQuery(prefix, null, suffix);
                 }
             case SEPSEQ:
                 List<Integer> withS = getSuccs(sample2(candidates));
                 Word<I> wit = ApartnessUtil.computeWitness(obsTree, withS.get(0), withS.get(1));
                 assert wit != null;
                 Word<I> inputSeq = prefix.concat(wit);
-                return Pair.of(inputSeq, this.outputQuery(inputSeq));
-            default:
-                throw new IllegalStateException("Shouldn't get here!");
-        }
+                yield Pair.of(inputSeq, this.outputQuery(inputSeq));
+        };
     }
 
     private List<Integer> getSuccs(Collection<Word<I>> candidates) {
@@ -148,16 +145,15 @@ public class LSOracle<I, O> {
         return candidates;
     }
 
-    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     private Pair<Word<I>, Word<O>> rule2IO(Word<I> accessQ, I i, List<Integer> bss, Collection<Word<I>> basis) {
-        switch (this.rule2) {
+        return switch (this.rule2) {
             case ADS:
                 ADSTree<Integer, I, O> suffix = new ADSTree<>(obsTree, bss, sinkOutput);
-                return this.adaptiveOutputQuery(accessQ, i, suffix);
+                yield this.adaptiveOutputQuery(accessQ, i, suffix);
             case NOTHING:
                 Word<I> prefix = accessQ.append(i);
                 Word<O> oSeq = this.outputQuery(prefix);
-                return Pair.of(prefix, oSeq);
+                yield Pair.of(prefix, oSeq);
             case SEPSEQ:
                 Word<I> wit;
                 if (basis.size() >= 2) {
@@ -169,10 +165,8 @@ public class LSOracle<I, O> {
                 }
                 Word<I> inputSeq = accessQ.append(i).concat(wit);
                 Word<O> outputSeq = this.outputQuery(inputSeq);
-                return Pair.of(inputSeq, outputSeq);
-            default:
-                throw new IllegalStateException("Shouldn't get here!");
-        }
+                yield Pair.of(inputSeq, outputSeq);
+        };
     }
 
     public List<Pair<Word<I>, List<Word<I>>>> exploreFrontier(Collection<Word<I>> basis) {

--- a/algorithms/active/lsharp/src/main/java/de/learnlib/algorithm/lsharp/ads/ADSTree.java
+++ b/algorithms/active/lsharp/src/main/java/de/learnlib/algorithm/lsharp/ads/ADSTree.java
@@ -110,7 +110,7 @@ public final class ADSTree<S extends Comparable<S>, I, O> implements ADS<I, O> {
             }
         }
 
-        assert bestInput != null && bestChildren != null;
+        assert bestInput != null;
 
         return new ADSNode<>(bestInput, toMap(bestChildren), bestIScore);
     }

--- a/algorithms/active/lstar/src/main/java/de/learnlib/algorithm/lstar/AbstractAutomatonLStar.java
+++ b/algorithms/active/lstar/src/main/java/de/learnlib/algorithm/lstar/AbstractAutomatonLStar.java
@@ -205,7 +205,7 @@ public abstract class AbstractAutomatonLStar<A, I, D, S, T, SP, TP, AI extends M
         }
     }
 
-    static final class StateInfo<S, I> {
+    protected static final class StateInfo<S, I> {
 
         private final Row<I> row;
         private final S state;

--- a/algorithms/active/lstar/src/main/java/de/learnlib/algorithm/lstar/closing/ClosingStrategy.java
+++ b/algorithms/active/lstar/src/main/java/de/learnlib/algorithm/lstar/closing/ClosingStrategy.java
@@ -29,6 +29,7 @@ import de.learnlib.oracle.MembershipOracle;
  * @param <D>
  *         type variable for output symbol upper bound.
  */
+@FunctionalInterface
 public interface ClosingStrategy<I, D> {
 
     /**

--- a/algorithms/active/ttt-vpa/src/main/java/de/learnlib/algorithm/ttt/vpa/Splitter.java
+++ b/algorithms/active/ttt-vpa/src/main/java/de/learnlib/algorithm/ttt/vpa/Splitter.java
@@ -61,26 +61,20 @@ public final class Splitter<I> {
         return succSeparator.getDiscriminator();
     }
 
-    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     public ContextPair<I> getNewDiscriminator() {
         Word<I> prefix = succSeparator.getDiscriminator().getPrefix();
         Word<I> suffix = succSeparator.getDiscriminator().getSuffix();
 
-        switch (type) {
-            case INTERNAL:
-                return new ContextPair<>(prefix, suffix.prepend(symbol));
-            case RETURN:
-                return new ContextPair<>(prefix.concat(location.getAccessSequence()).append(otherSymbol),
-                                         suffix.prepend(symbol));
-            case CALL:
-                return new ContextPair<>(prefix,
-                                         location.getAccessSequence()
-                                                 .prepend(symbol)
-                                                 .append(otherSymbol)
-                                                 .concat(suffix));
-            default:
-                throw new IllegalStateException("Unhandled type " + type);
-        }
+        return switch (type) {
+            case INTERNAL -> new ContextPair<>(prefix, suffix.prepend(symbol));
+            case RETURN -> new ContextPair<>(prefix.concat(location.getAccessSequence()).append(otherSymbol),
+                                             suffix.prepend(symbol));
+            case CALL -> new ContextPair<>(prefix,
+                                           location.getAccessSequence()
+                                                   .prepend(symbol)
+                                                   .append(otherSymbol)
+                                                   .concat(suffix));
+        };
     }
 
     public int getNewDiscriminatorLength() {

--- a/algorithms/active/ttt-vpa/src/main/java/de/learnlib/algorithm/ttt/vpa/Splitter.java
+++ b/algorithms/active/ttt-vpa/src/main/java/de/learnlib/algorithm/ttt/vpa/Splitter.java
@@ -61,6 +61,7 @@ public final class Splitter<I> {
         return succSeparator.getDiscriminator();
     }
 
+    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     public ContextPair<I> getNewDiscriminator() {
         Word<I> prefix = succSeparator.getDiscriminator().getPrefix();
         Word<I> suffix = succSeparator.getDiscriminator().getSuffix();

--- a/algorithms/active/ttt-vpa/src/main/java/de/learnlib/algorithm/ttt/vpa/TTTLearnerVPA.java
+++ b/algorithms/active/ttt-vpa/src/main/java/de/learnlib/algorithm/ttt/vpa/TTTLearnerVPA.java
@@ -214,12 +214,11 @@ public class TTTLearnerVPA<I> extends OPLearnerVPA<I> {
         return best;
     }
 
-    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     protected State<HypLoc<I>> getAnySuccessor(State<HypLoc<I>> state, I sym) {
         final VPAlphabet.SymbolType type = alphabet.getSymbolType(sym);
         final StackContents stackContents = state.getStackContents();
 
-        switch (type) {
+        return switch (type) {
             case INTERNAL: {
                 AbstractHypTrans<I> trans = hypothesis.getInternalTransition(state.getLocation(), sym);
                 HypLoc<I> succLoc;
@@ -228,11 +227,11 @@ public class TTTLearnerVPA<I> extends OPLearnerVPA<I> {
                 } else {
                     succLoc = trans.getNonTreeTarget().subtreeLocsIterator().next();
                 }
-                return new State<>(succLoc, stackContents);
+                yield new State<>(succLoc, stackContents);
             }
             case CALL: {
                 int stackSym = hypothesis.encodeStackSym(state.getLocation(), sym);
-                return new State<>(hypothesis.getInitialLocation(), StackContents.push(stackSym, stackContents));
+                yield new State<>(hypothesis.getInitialLocation(), StackContents.push(stackSym, stackContents));
             }
             case RETURN: {
                 assert stackContents != null;
@@ -244,11 +243,9 @@ public class TTTLearnerVPA<I> extends OPLearnerVPA<I> {
                 } else {
                     succLoc = trans.getNonTreeTarget().subtreeLocsIterator().next();
                 }
-                return new State<>(succLoc, stackContents.pop());
+                yield new State<>(succLoc, stackContents.pop());
             }
-            default:
-                throw new IllegalStateException("Unhandled type " + type);
-        }
+        };
     }
 
     private PrefixTransformAcex deriveAcex(OutputInconsistency<I> outIncons) {
@@ -592,18 +589,12 @@ public class TTTLearnerVPA<I> extends OPLearnerVPA<I> {
         }
     }
 
-    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     public AbstractHypTrans<I> getSplitterTrans(HypLoc<I> loc, Splitter<I> splitter) {
-        switch (splitter.type) {
-            case INTERNAL:
-                return hypothesis.getInternalTransition(loc, splitter.symbol);
-            case RETURN:
-                return hypothesis.getReturnTransition(loc, splitter.symbol, splitter.location, splitter.otherSymbol);
-            case CALL:
-                return hypothesis.getReturnTransition(splitter.location, splitter.otherSymbol, loc, splitter.symbol);
-            default:
-                throw new IllegalStateException("Unhandled type " + splitter.type);
-        }
+        return switch (splitter.type) {
+            case INTERNAL -> hypothesis.getInternalTransition(loc, splitter.symbol);
+            case RETURN -> hypothesis.getReturnTransition(loc, splitter.symbol, splitter.location, splitter.otherSymbol);
+            case CALL -> hypothesis.getReturnTransition(splitter.location, splitter.otherSymbol, loc, splitter.symbol);
+        };
     }
 
     private static <I> void moveIncoming(DTNode<I> newNode, DTNode<I> oldNode, Boolean label) {

--- a/algorithms/active/ttt-vpa/src/main/java/de/learnlib/algorithm/ttt/vpa/TTTLearnerVPA.java
+++ b/algorithms/active/ttt-vpa/src/main/java/de/learnlib/algorithm/ttt/vpa/TTTLearnerVPA.java
@@ -214,6 +214,7 @@ public class TTTLearnerVPA<I> extends OPLearnerVPA<I> {
         return best;
     }
 
+    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     protected State<HypLoc<I>> getAnySuccessor(State<HypLoc<I>> state, I sym) {
         final VPAlphabet.SymbolType type = alphabet.getSymbolType(sym);
         final StackContents stackContents = state.getStackContents();
@@ -591,6 +592,7 @@ public class TTTLearnerVPA<I> extends OPLearnerVPA<I> {
         }
     }
 
+    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     public AbstractHypTrans<I> getSplitterTrans(HypLoc<I> loc, Splitter<I> splitter) {
         switch (splitter.type) {
             case INTERNAL:

--- a/api/src/main/java/de/learnlib/AccessSequenceProvider.java
+++ b/api/src/main/java/de/learnlib/AccessSequenceProvider.java
@@ -24,6 +24,7 @@ import net.automatalib.word.Word;
  * @param <I>
  *         input symbol type
  */
+@FunctionalInterface
 public interface AccessSequenceProvider<I> {
 
     /**

--- a/api/src/main/java/de/learnlib/AccessSequenceTransformer.java
+++ b/api/src/main/java/de/learnlib/AccessSequenceTransformer.java
@@ -17,6 +17,7 @@ package de.learnlib;
 
 import net.automatalib.word.Word;
 
+@FunctionalInterface
 public interface AccessSequenceTransformer<I> {
 
     Word<I> transformAccessSequence(Word<I> word);

--- a/api/src/main/java/de/learnlib/TestWordGenerator.java
+++ b/api/src/main/java/de/learnlib/TestWordGenerator.java
@@ -29,6 +29,7 @@ import net.automatalib.word.Word;
  * @param <I>
  *         input symbol type
  */
+@FunctionalInterface
 public interface TestWordGenerator<A, I> {
 
     /**

--- a/api/src/main/java/de/learnlib/algorithm/LearnerConstructor.java
+++ b/api/src/main/java/de/learnlib/algorithm/LearnerConstructor.java
@@ -29,6 +29,7 @@ import net.automatalib.alphabet.Alphabet;
  * @param <D>
  *         output domain type
  */
+@FunctionalInterface
 public interface LearnerConstructor<L, I, D> {
 
     /**

--- a/api/src/main/java/de/learnlib/oracle/AdaptiveMembershipOracle.java
+++ b/api/src/main/java/de/learnlib/oracle/AdaptiveMembershipOracle.java
@@ -30,6 +30,7 @@ import de.learnlib.query.AdaptiveQuery.Response;
  * @param <O>
  *         output symbol type
  */
+@FunctionalInterface
 public interface AdaptiveMembershipOracle<I, O> extends BatchProcessor<AdaptiveQuery<I, O>> {
 
     /**

--- a/api/src/main/java/de/learnlib/oracle/BatchProcessor.java
+++ b/api/src/main/java/de/learnlib/oracle/BatchProcessor.java
@@ -26,6 +26,7 @@ import de.learnlib.exception.BatchInterruptedException;
  * @param <T>
  *         batch type
  */
+@FunctionalInterface
 public interface BatchProcessor<T> {
 
     /**

--- a/api/src/main/java/de/learnlib/oracle/EmptinessOracle.java
+++ b/api/src/main/java/de/learnlib/oracle/EmptinessOracle.java
@@ -38,6 +38,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @param <D>
  *         the output type
  */
+@FunctionalInterface
 public interface EmptinessOracle<A extends Output<I, D>, I, D> {
 
     default boolean isCounterExample(Output<I, D> hypothesis, Iterable<? extends I> input, D output) {
@@ -46,7 +47,9 @@ public interface EmptinessOracle<A extends Output<I, D>, I, D> {
 
     @Nullable DefaultQuery<I, D> findCounterExample(A hypothesis, Collection<? extends I> inputs);
 
+    @FunctionalInterface
     interface DFAEmptinessOracle<I> extends EmptinessOracle<DFA<?, I>, I, Boolean> {}
 
+    @FunctionalInterface
     interface MealyEmptinessOracle<I, O> extends EmptinessOracle<MealyMachine<?, I, ?, O>, I, Word<O>> {}
 }

--- a/api/src/main/java/de/learnlib/oracle/EquivalenceOracle.java
+++ b/api/src/main/java/de/learnlib/oracle/EquivalenceOracle.java
@@ -42,6 +42,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @param <D>
  *         output domain type
  */
+@FunctionalInterface
 public interface EquivalenceOracle<A, I, D> {
 
     /**
@@ -66,6 +67,7 @@ public interface EquivalenceOracle<A, I, D> {
      * @param <I>
      *         input symbol class
      */
+    @FunctionalInterface
     interface DFAEquivalenceOracle<I> extends EquivalenceOracle<DFA<?, I>, I, Boolean> {}
 
     /**
@@ -76,6 +78,7 @@ public interface EquivalenceOracle<A, I, D> {
      * @param <O>
      *         output symbol class
      */
+    @FunctionalInterface
     interface MealyEquivalenceOracle<I, O> extends EquivalenceOracle<MealyMachine<?, I, ?, O>, I, Word<O>> {}
 
     /**
@@ -86,6 +89,7 @@ public interface EquivalenceOracle<A, I, D> {
      * @param <O>
      *         output symbol class
      */
+    @FunctionalInterface
     interface MooreEquivalenceOracle<I, O> extends EquivalenceOracle<MooreMachine<?, I, ?, O>, I, Word<O>> {}
 
 }

--- a/api/src/main/java/de/learnlib/oracle/InclusionOracle.java
+++ b/api/src/main/java/de/learnlib/oracle/InclusionOracle.java
@@ -38,14 +38,17 @@ import net.automatalib.word.Word;
  * @param <D>
  *         the output type
  */
+@FunctionalInterface
 public interface InclusionOracle<A extends Output<I, D>, I, D> extends EquivalenceOracle<A, I, D> {
 
     default boolean isCounterExample(Output<I, D> hypothesis, Iterable<? extends I> input, D output) {
         return !Objects.equals(hypothesis.computeOutput(input), output);
     }
 
+    @FunctionalInterface
     interface DFAInclusionOracle<I> extends InclusionOracle<DFA<?, I>, I, Boolean>, DFAEquivalenceOracle<I> {}
 
+    @FunctionalInterface
     interface MealyInclusionOracle<I, O>
             extends InclusionOracle<MealyMachine<?, I, ?, O>, I, Word<O>>, MealyEquivalenceOracle<I, O> {}
 }

--- a/api/src/main/java/de/learnlib/oracle/LassoEmptinessOracle.java
+++ b/api/src/main/java/de/learnlib/oracle/LassoEmptinessOracle.java
@@ -29,9 +29,12 @@ import net.automatalib.word.Word;
  * @param <I> the input type
  * @param <D> the output type
  */
+@FunctionalInterface
 public interface LassoEmptinessOracle<L extends Lasso<I, D>, I, D> extends EmptinessOracle<L, I, D> {
 
+    @FunctionalInterface
     interface DFALassoEmptinessOracle<I> extends LassoEmptinessOracle<DFALasso<I>, I, Boolean> {}
 
+    @FunctionalInterface
     interface MealyLassoEmptinessOracle<I, O> extends LassoEmptinessOracle<MealyLasso<I, O>, I, Word<O>> {}
 }

--- a/api/src/main/java/de/learnlib/oracle/MembershipOracle.java
+++ b/api/src/main/java/de/learnlib/oracle/MembershipOracle.java
@@ -33,6 +33,7 @@ import net.automatalib.word.Word;
  *
  * @see DefaultQuery
  */
+@FunctionalInterface
 public interface MembershipOracle<I, D> extends QueryAnswerer<I, D>, BatchProcessor<Query<I, D>> {
 
     @Override
@@ -92,6 +93,7 @@ public interface MembershipOracle<I, D> extends QueryAnswerer<I, D>, BatchProces
      * @param <I>
      *         input symbol type
      */
+    @FunctionalInterface
     interface DFAMembershipOracle<I> extends MembershipOracle<I, Boolean> {}
 
     /**
@@ -105,6 +107,7 @@ public interface MembershipOracle<I, D> extends QueryAnswerer<I, D>, BatchProces
      * @param <O>
      *         output symbol type
      */
+    @FunctionalInterface
     interface MealyMembershipOracle<I, O> extends MembershipOracle<I, Word<O>> {}
 
     /**
@@ -118,6 +121,7 @@ public interface MembershipOracle<I, D> extends QueryAnswerer<I, D>, BatchProces
      * @param <O>
      *         output symbol type
      */
+    @FunctionalInterface
     interface MooreMembershipOracle<I, O> extends MembershipOracle<I, Word<O>> {}
 
 }

--- a/api/src/main/java/de/learnlib/oracle/QueryAnswerer.java
+++ b/api/src/main/java/de/learnlib/oracle/QueryAnswerer.java
@@ -25,6 +25,7 @@ import net.automatalib.word.Word;
  * @param <D>
  *         output domain type
  */
+@FunctionalInterface
 public interface QueryAnswerer<I, D> {
 
     default D answerQuery(Word<I> input) {

--- a/api/src/main/java/de/learnlib/oracle/SingleAdaptiveMembershipOracle.java
+++ b/api/src/main/java/de/learnlib/oracle/SingleAdaptiveMembershipOracle.java
@@ -25,6 +25,7 @@ import de.learnlib.query.AdaptiveQuery;
  * @see AdaptiveMembershipOracle
  * @see SingleQueryOracle
  */
+@FunctionalInterface
 public interface SingleAdaptiveMembershipOracle<I, O> extends AdaptiveMembershipOracle<I, O> {
 
     @Override

--- a/api/src/main/java/de/learnlib/oracle/SingleQueryOracle.java
+++ b/api/src/main/java/de/learnlib/oracle/SingleQueryOracle.java
@@ -32,6 +32,7 @@ import net.automatalib.word.Word;
  * @param <D>
  *         output domain type
  */
+@FunctionalInterface
 public interface SingleQueryOracle<I, D> extends MembershipOracle<I, D> {
 
     @Override
@@ -48,10 +49,13 @@ public interface SingleQueryOracle<I, D> extends MembershipOracle<I, D> {
     @Override
     D answerQuery(Word<I> prefix, Word<I> suffix);
 
+    @FunctionalInterface
     interface SingleQueryOracleDFA<I> extends SingleQueryOracle<I, Boolean>, DFAMembershipOracle<I> {}
 
+    @FunctionalInterface
     interface SingleQueryOracleMealy<I, O> extends SingleQueryOracle<I, Word<O>>, MealyMembershipOracle<I, O> {}
 
+    @FunctionalInterface
     interface SingleQueryOracleMoore<I, O> extends SingleQueryOracle<I, Word<O>>, MooreMembershipOracle<I, O> {}
 
 }

--- a/api/src/main/java/de/learnlib/query/OmegaQuery.java
+++ b/api/src/main/java/de/learnlib/query/OmegaQuery.java
@@ -102,16 +102,9 @@ public class OmegaQuery<I, D> {
 
     @Override
     public final boolean equals(@Nullable Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof OmegaQuery)) {
-            return false;
-        }
-
-        final OmegaQuery<?, ?> that = (OmegaQuery<?, ?>) o;
-        return periodicity == that.periodicity && Objects.equals(prefix, that.prefix) &&
-               Objects.equals(loop, that.loop) && Objects.equals(output, that.output);
+        return this == o || o instanceof OmegaQuery<?, ?> that && periodicity == that.periodicity &&
+                            Objects.equals(prefix, that.prefix) && Objects.equals(loop, that.loop) &&
+                            Objects.equals(output, that.output);
     }
 
     @Override

--- a/api/src/main/java/de/learnlib/query/Query.java
+++ b/api/src/main/java/de/learnlib/query/Query.java
@@ -118,15 +118,8 @@ public abstract class Query<I, D> {
 
     @Override
     public final boolean equals(@Nullable Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof Query)) {
-            return false;
-        }
-
-        final Query<?, ?> that = (Query<?, ?>) o;
-        return Objects.equals(getPrefix(), that.getPrefix()) && Objects.equals(getSuffix(), that.getSuffix());
+        return this == o || o instanceof Query<?, ?> that && Objects.equals(getPrefix(), that.getPrefix()) &&
+                            Objects.equals(getSuffix(), that.getSuffix());
     }
 
     /**

--- a/api/src/main/java/de/learnlib/statistic/StatisticCollector.java
+++ b/api/src/main/java/de/learnlib/statistic/StatisticCollector.java
@@ -19,6 +19,7 @@ package de.learnlib.statistic;
  * A utility interface to indicate that the implementing class collects statistical information that may be obtained via
  * its {@link #getStatisticalData()} method.
  */
+@FunctionalInterface
 public interface StatisticCollector {
 
     /**

--- a/api/src/main/java/de/learnlib/sul/ContextExecutableInput.java
+++ b/api/src/main/java/de/learnlib/sul/ContextExecutableInput.java
@@ -26,6 +26,7 @@ import de.learnlib.exception.SULException;
  * @param <C>
  *         context
  */
+@FunctionalInterface
 public interface ContextExecutableInput<O, C> {
 
     /**

--- a/api/src/main/java/de/learnlib/sul/ExecutableInput.java
+++ b/api/src/main/java/de/learnlib/sul/ExecutableInput.java
@@ -23,6 +23,7 @@ import de.learnlib.exception.SULException;
  * @param <O>
  *         output
  */
+@FunctionalInterface
 public interface ExecutableInput<O> {
 
     /**

--- a/build-config/src/main/resources/learnlib-pmd-ruleset.xml
+++ b/build-config/src/main/resources/learnlib-pmd-ruleset.xml
@@ -25,7 +25,6 @@ limitations under the License.
     <!-- EXCLUSIONS -->
 
     <rule ref="category/java/bestpractices.xml">
-        <exclude name="AccessorMethodGeneration"/> <!-- irrelevant once we target Java 11 -->
         <exclude name="ArrayIsStoredDirectly"/>
         <exclude name="LooseCoupling"/> <!-- may be enabled once calls on sub-type methods are filtered again -->
         <exclude name="GuardLogStatement"/>
@@ -55,7 +54,6 @@ limitations under the License.
         <exclude name="ShortClassName"/>
         <exclude name="ShortMethodName"/>
         <exclude name="ShortVariable"/>
-        <exclude name="UnnecessaryImport"/> <!-- flags imports required by JavaDoc -->
     </rule>
 
     <rule ref="category/java/design.xml">
@@ -102,9 +100,21 @@ limitations under the License.
 
     <!-- CONFIGS -->
 
+    <rule ref="category/java/codestyle.xml/ConfusingTernary">
+        <properties>
+            <property name="ignoreElseIf" value="true" />
+        </properties>
+    </rule>
+
     <rule ref="category/java/codestyle.xml/EmptyControlStatement">
         <properties>
             <property name="allowCommentedBlocks" value="true" />
+        </properties>
+    </rule>
+
+    <rule ref="category/java/codestyle.xml/TypeParameterNamingConventions">
+        <properties>
+            <property name="typeParameterNamePattern" value="[A-Z0-9]*" />
         </properties>
     </rule>
 
@@ -112,12 +122,6 @@ limitations under the License.
         <properties>
             <property name="reportStaticMethods" value="false" />
             <property name="reportStaticFields" value="false" />
-        </properties>
-    </rule>
-
-    <rule ref="category/java/codestyle.xml/ConfusingTernary">
-        <properties>
-            <property name="ignoreElseIf" value="true" />
         </properties>
     </rule>
 

--- a/commons/counterexamples/src/main/java/de/learnlib/acex/AcexAnalyzer.java
+++ b/commons/counterexamples/src/main/java/de/learnlib/acex/AcexAnalyzer.java
@@ -15,6 +15,7 @@
  */
 package de.learnlib.acex;
 
+@FunctionalInterface
 public interface AcexAnalyzer {
 
     /**

--- a/commons/counterexamples/src/main/java/de/learnlib/acex/AcexAnalyzers.java
+++ b/commons/counterexamples/src/main/java/de/learnlib/acex/AcexAnalyzers.java
@@ -108,6 +108,7 @@ public final class AcexAnalyzers {
         return result;
     }
 
+    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     public static Collection<AbstractNamedAcexAnalyzer> getAnalyzers(Direction dir) {
         switch (dir) {
             case FORWARD:

--- a/commons/counterexamples/src/main/java/de/learnlib/acex/AcexAnalyzers.java
+++ b/commons/counterexamples/src/main/java/de/learnlib/acex/AcexAnalyzers.java
@@ -108,16 +108,11 @@ public final class AcexAnalyzers {
         return result;
     }
 
-    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     public static Collection<AbstractNamedAcexAnalyzer> getAnalyzers(Direction dir) {
-        switch (dir) {
-            case FORWARD:
-                return getForwardAnalyzers();
-            case BACKWARD:
-                return getBackwardAnalyzers();
-            default:
-                throw new IllegalArgumentException();
-        }
+        return switch (dir) {
+            case FORWARD -> getForwardAnalyzers();
+            case BACKWARD -> getBackwardAnalyzers();
+        };
     }
 
     public static Collection<AbstractNamedAcexAnalyzer> getForwardAnalyzers() {

--- a/commons/counterexamples/src/main/java/de/learnlib/counterexample/GlobalSuffixFinder.java
+++ b/commons/counterexamples/src/main/java/de/learnlib/counterexample/GlobalSuffixFinder.java
@@ -41,6 +41,7 @@ import net.automatalib.word.Word;
  * @param <D>
  *         output domain type upper bound
  */
+@FunctionalInterface
 public interface GlobalSuffixFinder<I, D> {
 
     /**

--- a/commons/counterexamples/src/main/java/de/learnlib/counterexample/LocalSuffixFinder.java
+++ b/commons/counterexamples/src/main/java/de/learnlib/counterexample/LocalSuffixFinder.java
@@ -47,6 +47,7 @@ import net.automatalib.automaton.concept.SuffixOutput;
  * @param <D>
  *         output domain type upper bound
  */
+@FunctionalInterface
 public interface LocalSuffixFinder<I, D> {
 
     /**

--- a/commons/datastructures/src/main/java/de/learnlib/datastructure/discriminationtree/model/BooleanMap.java
+++ b/commons/datastructures/src/main/java/de/learnlib/datastructure/discriminationtree/model/BooleanMap.java
@@ -203,15 +203,7 @@ public class BooleanMap<V> extends AbstractMap<Boolean, V> {
 
         @Override
         public boolean equals(@Nullable Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (!(o instanceof BooleanMap.Entry)) {
-                return false;
-            }
-
-            final BooleanMap<?>.Entry that = (BooleanMap<?>.Entry) o;
-            return Objects.equals(key, that.key);
+            return this == o || o instanceof BooleanMap<?>.Entry that && Objects.equals(key, that.key);
         }
     }
 }

--- a/commons/datastructures/src/main/java/de/learnlib/datastructure/observationtable/ObservationTableFeature.java
+++ b/commons/datastructures/src/main/java/de/learnlib/datastructure/observationtable/ObservationTableFeature.java
@@ -15,6 +15,7 @@
  */
 package de.learnlib.datastructure.observationtable;
 
+@FunctionalInterface
 public interface ObservationTableFeature<I, D> {
 
     ObservationTable<I, D> getObservationTable();

--- a/commons/datastructures/src/main/java/de/learnlib/datastructure/observationtable/reader/ObservationTableReader.java
+++ b/commons/datastructures/src/main/java/de/learnlib/datastructure/observationtable/reader/ObservationTableReader.java
@@ -26,6 +26,7 @@ import net.automatalib.alphabet.Alphabet;
  * @param <D>
  *         observation (output) domain class
  */
+@FunctionalInterface
 public interface ObservationTableReader<I, D> {
 
     /**

--- a/commons/datastructures/src/main/java/de/learnlib/datastructure/observationtable/writer/ObservationTableWriter.java
+++ b/commons/datastructures/src/main/java/de/learnlib/datastructure/observationtable/writer/ObservationTableWriter.java
@@ -23,6 +23,7 @@ import java.io.Writer;
 import de.learnlib.datastructure.observationtable.ObservationTable;
 import net.automatalib.common.util.IOUtil;
 
+@FunctionalInterface
 public interface ObservationTableWriter<I, D> {
 
     void write(ObservationTable<? extends I, ? extends D> table, Appendable out) throws IOException;

--- a/commons/datastructures/src/main/java/de/learnlib/datastructure/pta/AbstractBlueFringePTAState.java
+++ b/commons/datastructures/src/main/java/de/learnlib/datastructure/pta/AbstractBlueFringePTAState.java
@@ -18,6 +18,10 @@ package de.learnlib.datastructure.pta;
 import net.automatalib.common.util.comparison.CmpUtil;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+/**
+ * Note: this class has a natural ordering that is inconsistent with equals.
+ */
+@SuppressWarnings("PMD.OverrideBothEqualsAndHashCodeOnComparable")
 public abstract class AbstractBlueFringePTAState<S extends AbstractBlueFringePTAState<S, SP, TP>, SP, TP>
         extends AbstractBasePTAState<S, SP, TP> implements Comparable<S> {
 

--- a/commons/datastructures/src/main/java/de/learnlib/datastructure/pta/config/ProcessingOrder.java
+++ b/commons/datastructures/src/main/java/de/learnlib/datastructure/pta/config/ProcessingOrder.java
@@ -32,6 +32,7 @@ import de.learnlib.datastructure.pta.PTATransition;
  *
  * @see DefaultProcessingOrders
  */
+@FunctionalInterface
 public interface ProcessingOrder {
 
     /**

--- a/commons/datastructures/src/main/java/de/learnlib/datastructure/pta/visualization/PTAVisualizationHelper.java
+++ b/commons/datastructures/src/main/java/de/learnlib/datastructure/pta/visualization/PTAVisualizationHelper.java
@@ -36,8 +36,8 @@ public class PTAVisualizationHelper<S, I, T, SP, TP, A extends UniversalDetermin
                                      Map<String, String> properties) {
         super.getEdgeProperties(src, edge, tgt, properties);
 
-        final I input = edge.getInput();
-        properties.put(EdgeAttrs.LABEL, input + " / " + automaton.getTransitionProperty(edge.getTransition()));
+        final I input = edge.input();
+        properties.put(EdgeAttrs.LABEL, input + " / " + automaton.getTransitionProperty(edge.transition()));
 
         return true;
     }

--- a/commons/settings/src/main/java/de/learnlib/setting/LearnLibSettingsSource.java
+++ b/commons/settings/src/main/java/de/learnlib/setting/LearnLibSettingsSource.java
@@ -17,4 +17,5 @@ package de.learnlib.setting;
 
 import net.automatalib.common.util.setting.SettingsSource;
 
+@FunctionalInterface
 public interface LearnLibSettingsSource extends SettingsSource {}

--- a/drivers/basic/src/main/java/de/learnlib/driver/reflect/Error.java
+++ b/drivers/basic/src/main/java/de/learnlib/driver/reflect/Error.java
@@ -39,15 +39,7 @@ public final class Error extends MethodOutput {
 
     @Override
     public boolean equals(@Nullable Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (!(obj instanceof Error)) {
-            return false;
-        }
-
-        final Error other = (Error) obj;
-        return Objects.equals(this.id, other.id);
+        return this == obj || obj instanceof Error other && Objects.equals(this.id, other.id);
     }
 
     @Override

--- a/drivers/basic/src/main/java/de/learnlib/driver/reflect/InstanceConstructor.java
+++ b/drivers/basic/src/main/java/de/learnlib/driver/reflect/InstanceConstructor.java
@@ -31,7 +31,6 @@ final class InstanceConstructor implements ContextHandler<Object> {
         this.params = params;
     }
 
-    @SuppressWarnings("PMD.PreserveStackTrace")
     @Override
     public Object createContext() {
         try {

--- a/drivers/basic/src/main/java/de/learnlib/driver/reflect/MethodInput.java
+++ b/drivers/basic/src/main/java/de/learnlib/driver/reflect/MethodInput.java
@@ -36,7 +36,6 @@ public class MethodInput implements ContextExecutableInput<MethodOutput, Object>
         this.parameters = parameters;
     }
 
-    @SuppressWarnings("PMD.PreserveStackTrace")
     @Override
     public MethodOutput execute(Object context) {
         try {

--- a/drivers/basic/src/main/java/de/learnlib/driver/reflect/ReturnValue.java
+++ b/drivers/basic/src/main/java/de/learnlib/driver/reflect/ReturnValue.java
@@ -40,15 +40,7 @@ public final class ReturnValue<T> extends MethodOutput {
 
     @Override
     public boolean equals(@Nullable Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (!(obj instanceof ReturnValue)) {
-            return false;
-        }
-
-        final ReturnValue<?> other = (ReturnValue<?>) obj;
-        return Objects.equals(this.ret, other.ret);
+        return this == obj || obj instanceof ReturnValue<?> other && Objects.equals(this.ret, other.ret);
     }
 
     @Override

--- a/drivers/mapper/src/test/java/de/learnlib/mapper/SULMapperCompositionTest.java
+++ b/drivers/mapper/src/test/java/de/learnlib/mapper/SULMapperCompositionTest.java
@@ -126,16 +126,12 @@ public class SULMapperCompositionTest {
 
         @Override
         public Character step(Character in) {
-            switch (in) {
-                case OUTER_EXCEPTION_TRIGGER_CHAR:
-                    throw new OuterWrappedException(new IllegalArgumentException());
-                case INNER_EXCEPTION_TRIGGER_CHAR:
-                    throw new InnerUnwrappedException();
-                case NESTED_EXCEPTION_TRIGGER_CHAR:
-                    throw new NestedUnwrappedException();
-                default:
-                    return in;
-            }
+            return switch (in) {
+                case OUTER_EXCEPTION_TRIGGER_CHAR -> throw new OuterWrappedException(new IllegalArgumentException());
+                case INNER_EXCEPTION_TRIGGER_CHAR -> throw new InnerUnwrappedException();
+                case NESTED_EXCEPTION_TRIGGER_CHAR -> throw new NestedUnwrappedException();
+                default -> in;
+            };
         }
     }
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -193,12 +193,35 @@ limitations under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
+                    <!-- For some reason (probably due to the testing dependencies) surefire auto-detects a JUnit runner.
+                         Since we use testng exclusively, help the plugin a little bit -->
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.maven.surefire</groupId>
+                            <artifactId>surefire-testng</artifactId>
+                            <version>${surefire-plugin.version}</version>
+                        </dependency>
+                    </dependencies>
                     <configuration>
                         <systemPropertyVariables>
-                            <awt.toolkit>com.github.caciocavallosilano.cacio.ctc.CTCToolkit</awt.toolkit>
-                            <java.awt.graphicsenv>com.github.caciocavallosilano.cacio.ctc.CTCGraphicsEnvironment</java.awt.graphicsenv>
                             <java.awt.headless>false</java.awt.headless>
                         </systemPropertyVariables>
+                        <argLine>
+                            @{argLine}
+                            --add-exports=java.desktop/java.awt=ALL-UNNAMED
+                            --add-exports=java.desktop/java.awt.peer=ALL-UNNAMED
+                            --add-exports=java.desktop/sun.awt.image=ALL-UNNAMED
+                            --add-exports=java.desktop/sun.java2d=ALL-UNNAMED
+                            --add-exports=java.desktop/java.awt.dnd.peer=ALL-UNNAMED
+                            --add-exports=java.desktop/sun.awt=ALL-UNNAMED
+                            --add-exports=java.desktop/sun.awt.event=ALL-UNNAMED
+                            --add-exports=java.desktop/sun.awt.datatransfer=ALL-UNNAMED
+                            --add-exports=java.base/sun.security.action=ALL-UNNAMED
+                            --add-opens=java.base/java.util=ALL-UNNAMED
+                            --add-opens=java.desktop/java.awt=ALL-UNNAMED
+                            --add-opens=java.desktop/sun.java2d=ALL-UNNAMED
+                            --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+                        </argLine>
                     </configuration>
                 </plugin>
             </plugins>

--- a/examples/src/main/java/de/learnlib/example/Example3.java
+++ b/examples/src/main/java/de/learnlib/example/Example3.java
@@ -161,16 +161,14 @@ public class Example3 {
     }
 
     private @Nullable String exec(BoundedStringQueue s, String input) {
-        switch (input) {
-            case OFFER_1:
-            case OFFER_2:
+        return switch (input) {
+            case OFFER_1, OFFER_2 -> {
                 s.offer(input);
-                return "void";
-            case POLL:
-                return s.poll();
-            default:
-                throw new IllegalArgumentException("unknown input symbol");
-        }
+                yield "void";
+            }
+            case POLL -> s.poll();
+            default -> throw new IllegalArgumentException("unknown input symbol");
+        };
     }
 
     /**

--- a/examples/src/main/java/de/learnlib/example/aaar/AlternatingBitExampleExplicit.java
+++ b/examples/src/main/java/de/learnlib/example/aaar/AlternatingBitExampleExplicit.java
@@ -127,14 +127,11 @@ public final class AlternatingBitExampleExplicit {
 
         @Override
         public Event getRepresentative(String a) {
-            switch (a) {
-                case "recv":
-                    return new Recv();
-                case "msg":
-                    return new Msg<>(0, "d");
-                default:
-                    throw new IllegalArgumentException("Unknown abstract: " + a);
-            }
+            return switch (a) {
+                case "recv" -> new Recv();
+                case "msg" -> new Msg<>(0, "d");
+                default -> throw new IllegalArgumentException("Unknown abstract: " + a);
+            };
         }
 
         @Override

--- a/examples/src/main/java/de/learnlib/example/aaar/Event.java
+++ b/examples/src/main/java/de/learnlib/example/aaar/Event.java
@@ -38,12 +38,8 @@ class Event {
 
         @Override
         public boolean equals(@Nullable Object o) {
-            if (!(o instanceof Msg)) {
-                return false;
-            }
-            final Msg<?> that = (Msg<?>) o;
-
-            return this.seq == that.seq && Objects.equals(this.data, that.data);
+            return this == o ||
+                   o instanceof Msg<?> that && this.seq == that.seq && Objects.equals(this.data, that.data);
         }
 
         @Override

--- a/examples/src/main/java/de/learnlib/example/aaar/Protocol.java
+++ b/examples/src/main/java/de/learnlib/example/aaar/Protocol.java
@@ -41,15 +41,12 @@ class Protocol implements SingleQueryOracleMealy<Event, String> {
     }
 
     private String handleEvent(Event event) {
-        if (event instanceof Msg<?>) {
-            Msg<?> msg = (Msg<?>) event;
-
+        if (event instanceof Msg<?> msg) {
             if (buffer == null && msg.seq % 2 == seqExp % 2) {
                 buffer = msg.data;
                 seqExp++;
                 return "ind";
             }
-
             return "-";
         } else if (event instanceof Recv) {
             if (buffer == null) {

--- a/examples/src/test/java/de/learnlib/example/ExamplesTest.java
+++ b/examples/src/test/java/de/learnlib/example/ExamplesTest.java
@@ -25,6 +25,7 @@ import java.lang.reflect.InvocationTargetException;
 
 import javax.swing.SwingUtilities;
 
+import com.github.caciocavallosilano.cacio.ctc.junit.CacioExtension;
 import de.learnlib.example.aaar.AlternatingBitExampleExplicit;
 import de.learnlib.example.aaar.AlternatingBitExampleGeneric;
 import net.automatalib.modelchecker.ltsmin.LTSminUtil;
@@ -40,6 +41,9 @@ public class ExamplesTest {
     @BeforeClass
     public void setupAutoClose() {
         if (isJVMCompatible()) {
+            // hack: the static initializer of this class does the magic we want, so only invoke it on compatible JVMs
+            new CacioExtension();
+
             // As soon as we observe an event that indicates a new window, close it to prevent blocking the tests.
             Toolkit.getDefaultToolkit().addAWTEventListener(event -> {
                 final WindowEvent windowEvent = (WindowEvent) event;
@@ -173,12 +177,13 @@ public class ExamplesTest {
     }
 
     private static boolean isJVMCompatible() {
-        return Runtime.version().feature() == 11;
+        final int feature = Runtime.version().feature();
+        return feature == 17 || feature == 21;
     }
 
     private static void requireJVMCompatibility() {
-        if (Runtime.version().feature() != 11) {
-            throw new SkipException("The headless AWT environment currently only works with Java 11 or <=8");
+        if (!isJVMCompatible()) {
+            throw new SkipException("The headless AWT environment only works with specific JVM versions");
         }
     }
 

--- a/filters/cache/src/main/java/de/learnlib/filter/cache/LearningCache.java
+++ b/filters/cache/src/main/java/de/learnlib/filter/cache/LearningCache.java
@@ -40,6 +40,7 @@ import net.automatalib.word.Word;
  * @param <O>
  *         output symbol type
  */
+@FunctionalInterface
 public interface LearningCache<A, I, O> {
 
     /**
@@ -59,6 +60,7 @@ public interface LearningCache<A, I, O> {
      * @param <I>
      *         input symbol type
      */
+    @FunctionalInterface
     interface DFALearningCache<I> extends LearningCache<DFA<?, I>, I, Boolean> {}
 
     /**
@@ -69,6 +71,7 @@ public interface LearningCache<A, I, O> {
      * @param <O>
      *         output symbol type
      */
+    @FunctionalInterface
     interface MealyLearningCache<I, O> extends LearningCache<MealyMachine<?, I, ?, O>, I, Word<O>> {}
 
     /**
@@ -79,5 +82,6 @@ public interface LearningCache<A, I, O> {
      * @param <O>
      *         output symbol type
      */
+    @FunctionalInterface
     interface MooreLearningCache<I, O> extends LearningCache<MooreMachine<?, I, ?, O>, I, Word<O>> {}
 }

--- a/filters/cache/src/main/java/de/learnlib/filter/cache/mealy/AdaptiveQueryCache.java
+++ b/filters/cache/src/main/java/de/learnlib/filter/cache/mealy/AdaptiveQueryCache.java
@@ -276,15 +276,14 @@ public class AdaptiveQueryCache<I, O> implements AdaptiveMembershipOracle<I, O>,
 
             final Response response = delegate.processOutput(out);
 
-            switch (response) {
-                case FINISHED:
+            return switch (response) {
+                case FINISHED -> {
                     isFinished = true;
-                    return Response.FINISHED;
-                case RESET:
-                    return Response.FINISHED;
-                default:
-                    return response;
-            }
+                    yield Response.FINISHED;
+                }
+                case RESET -> Response.FINISHED;
+                case SYMBOL -> response;
+            };
         }
     }
 

--- a/filters/reuse/src/main/java/de/learnlib/filter/reuse/tree/BoundedDeque.java
+++ b/filters/reuse/src/main/java/de/learnlib/filter/reuse/tree/BoundedDeque.java
@@ -100,14 +100,11 @@ public class BoundedDeque<E> extends AbstractCollection<E> {
      * @return the evicted element, may be {@code null} if the queue was empty
      */
     private @Nullable E evict() {
-        switch (evictPolicy) {
-            case EVICT_OLDEST:
-                return deque.pollFirst();
-            case EVICT_NEWEST:
-                return deque.pollLast();
-            default:
-                throw new IllegalStateException("Illegal evict policy: " + evictPolicy);
-        }
+        return switch (evictPolicy) {
+            case EVICT_OLDEST -> deque.pollFirst();
+            case EVICT_NEWEST -> deque.pollLast();
+            default -> throw new IllegalStateException("Illegal evict policy: " + evictPolicy);
+        };
     }
 
     /**
@@ -116,16 +113,11 @@ public class BoundedDeque<E> extends AbstractCollection<E> {
      *
      * @return the evicted element, may be {@code null} if the queue was empty
      */
-    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     public @Nullable E retrieve() {
-        switch (accessPolicy) {
-            case LIFO:
-                return deque.pollLast();
-            case FIFO:
-                return deque.pollFirst();
-            default:
-                throw new IllegalStateException("Illegal evict policy: " + evictPolicy);
-        }
+        return switch (accessPolicy) {
+            case LIFO -> deque.pollLast();
+            case FIFO -> deque.pollFirst();
+        };
     }
 
     /**
@@ -134,16 +126,11 @@ public class BoundedDeque<E> extends AbstractCollection<E> {
      *
      * @return the top-most element of the container
      */
-    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     public @Nullable E peek() {
-        switch (accessPolicy) {
-            case LIFO:
-                return deque.peekLast();
-            case FIFO:
-                return deque.peekFirst();
-            default:
-                throw new IllegalStateException("Illegal evict policy: " + evictPolicy);
-        }
+        return switch (accessPolicy) {
+            case LIFO -> deque.peekLast();
+            case FIFO -> deque.peekFirst();
+        };
     }
 
     /**

--- a/filters/reuse/src/main/java/de/learnlib/filter/reuse/tree/BoundedDeque.java
+++ b/filters/reuse/src/main/java/de/learnlib/filter/reuse/tree/BoundedDeque.java
@@ -116,6 +116,7 @@ public class BoundedDeque<E> extends AbstractCollection<E> {
      *
      * @return the evicted element, may be {@code null} if the queue was empty
      */
+    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     public @Nullable E retrieve() {
         switch (accessPolicy) {
             case LIFO:
@@ -133,6 +134,7 @@ public class BoundedDeque<E> extends AbstractCollection<E> {
      *
      * @return the top-most element of the container
      */
+    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     public @Nullable E peek() {
         switch (accessPolicy) {
             case LIFO:

--- a/filters/reuse/src/main/java/de/learnlib/filter/reuse/tree/SystemStateHandler.java
+++ b/filters/reuse/src/main/java/de/learnlib/filter/reuse/tree/SystemStateHandler.java
@@ -31,6 +31,7 @@ import de.learnlib.filter.reuse.ReuseOracleBuilder;
  * @param <S>
  *         system state class
  */
+@FunctionalInterface
 public interface SystemStateHandler<S> {
 
     /**

--- a/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/RandomWMethodEQOracle.java
+++ b/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/RandomWMethodEQOracle.java
@@ -186,6 +186,7 @@ public class RandomWMethodEQOracle<A extends UniversalDeterministicAutomaton<?, 
 
     @Override
     public Stream<Word<I>> generateTestWords(A hypothesis, Collection<? extends I> inputs) {
+        // explicitly assign type to (redundant) variable, otherwise javac complains
         UniversalDeterministicAutomaton<?, I, ?, ?, ?> aut = hypothesis;
         return doGenerateTestWords(aut, inputs);
     }

--- a/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/RandomWpMethodEQOracle.java
+++ b/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/RandomWpMethodEQOracle.java
@@ -187,6 +187,7 @@ public class RandomWpMethodEQOracle<A extends UniversalDeterministicAutomaton<?,
 
     @Override
     public Stream<Word<I>> generateTestWords(A hypothesis, Collection<? extends I> inputs) {
+        // explicitly assign type to (redundant) variable, otherwise javac complains
         UniversalDeterministicAutomaton<?, I, ?, ?, ?> aut = hypothesis;
         return doGenerateTestWords(aut, inputs);
     }

--- a/oracles/parallelism/src/main/java/de/learnlib/oracle/parallelism/AbstractDynamicBatchProcessorBuilder.java
+++ b/oracles/parallelism/src/main/java/de/learnlib/oracle/parallelism/AbstractDynamicBatchProcessorBuilder.java
@@ -123,7 +123,6 @@ public abstract class AbstractDynamicBatchProcessorBuilder<Q, P extends BatchPro
      *
      * @return the batch processor
      */
-    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     public OR create() {
         final Supplier<? extends P> supplier;
         final int size;
@@ -145,16 +144,10 @@ public abstract class AbstractDynamicBatchProcessorBuilder<Q, P extends BatchPro
         if (customExecutor != null) {
             executor = customExecutor;
         } else {
-            switch (poolPolicy) {
-                case FIXED:
-                    executor = Executors.newFixedThreadPool(size);
-                    break;
-                case CACHED:
-                    executor = new ScalingThreadPoolExecutor(0, size, DEFAULT_KEEP_ALIVE_TIME, TimeUnit.SECONDS);
-                    break;
-                default:
-                    throw new IllegalStateException("Unknown pool policy: " + poolPolicy);
-            }
+            executor = switch (poolPolicy) {
+                case FIXED -> Executors.newFixedThreadPool(size);
+                case CACHED -> new ScalingThreadPoolExecutor(0, size, DEFAULT_KEEP_ALIVE_TIME, TimeUnit.SECONDS);
+            };
         }
 
         return buildOracle(supplier, batchSize, executor);

--- a/oracles/parallelism/src/main/java/de/learnlib/oracle/parallelism/AbstractDynamicBatchProcessorBuilder.java
+++ b/oracles/parallelism/src/main/java/de/learnlib/oracle/parallelism/AbstractDynamicBatchProcessorBuilder.java
@@ -123,6 +123,7 @@ public abstract class AbstractDynamicBatchProcessorBuilder<Q, P extends BatchPro
      *
      * @return the batch processor
      */
+    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     public OR create() {
         final Supplier<? extends P> supplier;
         final int size;

--- a/oracles/parallelism/src/main/java/de/learnlib/oracle/parallelism/AbstractStaticBatchProcessorBuilder.java
+++ b/oracles/parallelism/src/main/java/de/learnlib/oracle/parallelism/AbstractStaticBatchProcessorBuilder.java
@@ -118,6 +118,7 @@ public abstract class AbstractStaticBatchProcessorBuilder<Q, P extends BatchProc
      *
      * @return the batch processor
      */
+    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     public OR create() {
         final ArrayStorage<P> instances;
         final int size;

--- a/oracles/parallelism/src/main/java/de/learnlib/oracle/parallelism/AbstractStaticBatchProcessorBuilder.java
+++ b/oracles/parallelism/src/main/java/de/learnlib/oracle/parallelism/AbstractStaticBatchProcessorBuilder.java
@@ -118,7 +118,6 @@ public abstract class AbstractStaticBatchProcessorBuilder<Q, P extends BatchProc
      *
      * @return the batch processor
      */
-    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     public OR create() {
         final ArrayStorage<P> instances;
         final int size;
@@ -143,16 +142,10 @@ public abstract class AbstractStaticBatchProcessorBuilder<Q, P extends BatchProc
         if (customExecutor != null) {
             executor = customExecutor;
         } else {
-            switch (poolPolicy) {
-                case FIXED:
-                    executor = Executors.newFixedThreadPool(size);
-                    break;
-                case CACHED:
-                    executor = new ScalingThreadPoolExecutor(0, size, DEFAULT_KEEP_ALIVE_TIME, TimeUnit.SECONDS);
-                    break;
-                default:
-                    throw new IllegalStateException("Unknown pool policy: " + poolPolicy);
-            }
+            executor = switch (poolPolicy) {
+                case FIXED -> Executors.newFixedThreadPool(size);
+                case CACHED -> new ScalingThreadPoolExecutor(0, size, DEFAULT_KEEP_ALIVE_TIME, TimeUnit.SECONDS);
+            };
         }
 
         return buildOracle(instances, minBatchSize, executor);

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,9 @@ limitations under the License.
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.testSource>17</maven.compiler.testSource>
+        <maven.compiler.testTarget>17</maven.compiler.testTarget>
+        <maven.compiler.testRelease>17</maven.compiler.testRelease>
         <argLine /> <!-- compatibility for property expansion in surefire-plugin -->
 
         <!-- plugin versions -->
@@ -260,7 +263,7 @@ limitations under the License.
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <logback.version>1.5.15</logback.version>
         <metainf-services.version>1.11</metainf-services.version>
-        <mockito.version>5.14.2</mockito.version>
+        <mockito.version>5.20.0</mockito.version>
         <slf4j.version>2.0.16</slf4j.version>
         <testng.version>7.10.2</testng.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -242,13 +242,13 @@ limitations under the License.
         <jar-plugin.version>3.4.2</jar-plugin.version>
         <javadoc-plugin.version>3.11.2</javadoc-plugin.version>
         <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
-        <pmd-plugin.version>3.26.0</pmd-plugin.version>
+        <pmd-plugin.version>3.28.0</pmd-plugin.version>
         <release-plugin.version>3.1.0</release-plugin.version>
         <resources-plugin.version>3.3.1</resources-plugin.version>
         <scm-publish-plugin.version>3.3.0</scm-publish-plugin.version>
         <site-plugin.version>3.21.0</site-plugin.version>
         <source-plugin.version>3.3.1</source-plugin.version>
-        <spotbugs-plugin.version>4.8.6.6</spotbugs-plugin.version>
+        <spotbugs-plugin.version>4.9.7.0</spotbugs-plugin.version>
         <surefire-plugin.version>3.5.2</surefire-plugin.version>
         <tidy-pom.version>1.3.0</tidy-pom.version>
 
@@ -258,7 +258,7 @@ limitations under the License.
         <cacio.version>1.11.1</cacio.version>
         <checkerframework.version>3.48.3</checkerframework.version>
         <checkstyle.version>10.21.1</checkstyle.version>
-        <extra-enforcer-rules.version>1.7.0</extra-enforcer-rules.version>
+        <extra-enforcer-rules.version>1.10.0</extra-enforcer-rules.version>
         <fury.version>0.9.0</fury.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <logback.version>1.5.15</logback.version>

--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@ limitations under the License.
         <info-reports-plugin.version>3.8.0</info-reports-plugin.version>
         <install-plugin.version>3.1.3</install-plugin.version>
         <invoker-plugin.version>3.9.0</invoker-plugin.version>
-        <jacoco-plugin.version>0.8.12</jacoco-plugin.version>
+        <jacoco-plugin.version>0.8.13</jacoco-plugin.version>
         <jar-plugin.version>3.4.2</jar-plugin.version>
         <javadoc-plugin.version>3.11.2</javadoc-plugin.version>
         <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
@@ -245,14 +245,14 @@ limitations under the License.
         <scm-publish-plugin.version>3.3.0</scm-publish-plugin.version>
         <site-plugin.version>3.21.0</site-plugin.version>
         <source-plugin.version>3.3.1</source-plugin.version>
-        <spotbugs-plugin.version>4.9.7.0</spotbugs-plugin.version>
+        <spotbugs-plugin.version>4.9.8.1</spotbugs-plugin.version>
         <surefire-plugin.version>3.5.2</surefire-plugin.version>
         <tidy-pom.version>1.3.0</tidy-pom.version>
 
         <!-- dependency versions -->
         <automatalib.version>0.13.0-SNAPSHOT</automatalib.version>
         <build-tools.version>0.1.1</build-tools.version>
-        <cacio.version>1.11.1</cacio.version>
+        <cacio.version>1.18</cacio.version>
         <checkerframework.version>3.48.3</checkerframework.version>
         <checkstyle.version>10.21.1</checkstyle.version>
         <extra-enforcer-rules.version>1.10.0</extra-enforcer-rules.version>
@@ -1216,15 +1216,6 @@ limitations under the License.
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-            <id>jdk17-compat</id>
-            <activation>
-                <jdk>17</jdk>
-            </activation>
-            <properties>
-                <cacio.version>1.17.3</cacio.version>
-            </properties>
         </profile>
         <profile>
             <!-- define module in a profile so that we can disable it during a release -->

--- a/pom.xml
+++ b/pom.xml
@@ -213,12 +213,9 @@ limitations under the License.
         <!-- general config -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.release>11</maven.compiler.release>
-        <maven.compiler.testSource>17</maven.compiler.testSource>
-        <maven.compiler.testTarget>17</maven.compiler.testTarget>
-        <maven.compiler.testRelease>17</maven.compiler.testRelease>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
         <argLine /> <!-- compatibility for property expansion in surefire-plugin -->
 
         <!-- plugin versions -->

--- a/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/PassiveLearnerVariantList.java
+++ b/test-support/learner-it-support/src/main/java/de/learnlib/testsupport/it/learner/PassiveLearnerVariantList.java
@@ -22,6 +22,7 @@ import net.automatalib.automaton.transducer.MooreMachine;
 import net.automatalib.automaton.transducer.SubsequentialTransducer;
 import net.automatalib.word.Word;
 
+@FunctionalInterface
 public interface PassiveLearnerVariantList<M, I, D> {
 
     /**
@@ -37,12 +38,16 @@ public interface PassiveLearnerVariantList<M, I, D> {
      */
     void addLearnerVariant(String name, PassiveLearningAlgorithm<? extends M, I, D> learner);
 
+    @FunctionalInterface
     interface DFALearnerVariantList<I> extends PassiveLearnerVariantList<DFA<?, I>, I, Boolean> {}
 
+    @FunctionalInterface
     interface MealyLearnerVariantList<I, O> extends PassiveLearnerVariantList<MealyMachine<?, I, ?, O>, I, Word<O>> {}
 
+    @FunctionalInterface
     interface MooreLearnerVariantList<I, O> extends PassiveLearnerVariantList<MooreMachine<?, I, ?, O>, I, Word<O>> {}
 
+    @FunctionalInterface
     interface SSTLearnerVariantList<I, O>
             extends PassiveLearnerVariantList<SubsequentialTransducer<?, I, ?, O>, I, Word<O>> {}
 }

--- a/test-support/learning-examples/src/main/java/de/learnlib/testsupport/example/PassiveLearningExample.java
+++ b/test-support/learning-examples/src/main/java/de/learnlib/testsupport/example/PassiveLearningExample.java
@@ -20,15 +20,20 @@ import java.util.Collection;
 import de.learnlib.query.DefaultQuery;
 import net.automatalib.word.Word;
 
+@FunctionalInterface
 public interface PassiveLearningExample<I, D> {
 
     Collection<DefaultQuery<I, D>> getSamples();
 
+    @FunctionalInterface
     interface DFAPassiveLearningExample<I> extends PassiveLearningExample<I, Boolean> {}
 
+    @FunctionalInterface
     interface MealyPassiveLearningExample<I, O> extends PassiveLearningExample<I, Word<O>> {}
 
+    @FunctionalInterface
     interface MoorePassiveLearningExample<I, O> extends PassiveLearningExample<I, Word<O>> {}
 
+    @FunctionalInterface
     interface SSTPassiveLearningExample<I, O> extends PassiveLearningExample<I, Word<O>> {}
 }

--- a/test-support/test-support/src/main/java/de/learnlib/testsupport/AbstractBFOracleTest.java
+++ b/test-support/test-support/src/main/java/de/learnlib/testsupport/AbstractBFOracleTest.java
@@ -47,7 +47,6 @@ public abstract class AbstractBFOracleTest<D> {
     }
 
     @AfterMethod
-    @SuppressWarnings("PMD.SignatureDeclareThrowsException")
     public void tearDown() throws Exception {
         this.mock.close();
     }


### PR DESCRIPTION
This PR raises the minimal Java version to 17 and includes certain cleanups that the new language features allow for.

Addtionally, it adds support for the new Java LTS version 25. As this requires a bump in our analysis plugins which include new/improved checks, this also contains the necessary refactorings to make the build process pass again.
