### PR TITLE
Add `Resumable` support for remaining Lambda learners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added a new (L*-based) learning algorithm for *Mealy machines with local timers* (MMLTs), including support for parallel queries, caching, and conformance testing (thanks to [Paul Kogel](https://github.com/pdev55)).
 * Added the L<sup>s</sup> active learning algorithm for Mealy machines (thanks to [Wolffhardt Schwabe](https://github.com/stateMachinist)).
 * Added an `EarlyExitEQOracle` which for a given `AdaptiveMembershipOracle` and `TestWordGenerator` stops the evaluation of (potentially long) Mealy-based equivalence tests as soon as a mismatch with the hypothesis is detected, potentially improving the symbol performance of the given equivalence oracle.
+* Both lambda learners (`LLambda{DFA,Mealy}` and `TTTLambda{DFA,Mealy}`) now support the `Resumable` interface.
 
 ### Changed
 

--- a/algorithms/active/lambda/pom.xml
+++ b/algorithms/active/lambda/pom.xml
@@ -63,6 +63,10 @@ limitations under the License.
             <groupId>org.checkerframework</groupId>
             <artifactId>checker-qual</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
 
         <!-- test -->
         <dependency>

--- a/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/lstar/AbstractLLambda.java
+++ b/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/lstar/AbstractLLambda.java
@@ -29,6 +29,7 @@ import java.util.Set;
 
 import de.learnlib.Resumable;
 import de.learnlib.algorithm.LearningAlgorithm;
+import de.learnlib.logging.Category;
 import de.learnlib.oracle.MembershipOracle;
 import de.learnlib.query.DefaultQuery;
 import de.learnlib.util.MQUtil;
@@ -37,11 +38,15 @@ import net.automatalib.alphabet.SupportsGrowingAlphabet;
 import net.automatalib.automaton.concept.FiniteRepresentation;
 import net.automatalib.automaton.concept.SuffixOutput;
 import net.automatalib.word.Word;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 abstract class AbstractLLambda<M extends SuffixOutput<I, D>, I, D> implements LearningAlgorithm<M, I, D>,
                                                                               SupportsGrowingAlphabet<I>,
                                                                               Resumable<LLambdaState<I, D>>,
                                                                               FiniteRepresentation {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractLLambda.class);
 
     final Alphabet<I> alphabet;
     final MembershipOracle<I, D> mqs;
@@ -305,7 +310,7 @@ abstract class AbstractLLambda<M extends SuffixOutput<I, D>, I, D> implements Le
 
     @Override
     public LLambdaState<I, D> suspend() {
-        return new LLambdaState<>(shortPrefixes, rows, suffixes);
+        return new LLambdaState<>(alphabet, shortPrefixes, rows, suffixes);
     }
 
     @Override
@@ -313,6 +318,14 @@ abstract class AbstractLLambda<M extends SuffixOutput<I, D>, I, D> implements Le
         this.shortPrefixes.clear();
         this.rows.clear();
         this.suffixes.clear();
+
+        final Alphabet<I> oldAlphabet = state.getAlphabet();
+        if (!this.alphabet.equals(oldAlphabet)) {
+            LOGGER.warn(Category.DATASTRUCTURE,
+                        "The current alphabet '{}' differs from the resumed alphabet '{}'. Future behavior may be inconsistent",
+                        this.alphabet,
+                        oldAlphabet);
+        }
 
         this.shortPrefixes.addAll(state.getShortPrefixes());
         this.rows.putAll(state.getRows());

--- a/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/lstar/LLambdaState.java
+++ b/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/lstar/LLambdaState.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Set;
 
 import de.learnlib.Resumable;
+import net.automatalib.alphabet.Alphabet;
 import net.automatalib.word.Word;
 
 /**
@@ -32,14 +33,20 @@ import net.automatalib.word.Word;
  */
 public class LLambdaState<I, D> {
 
+    private final Alphabet<I> alphabet;
     private final Set<Word<I>> shortPrefixes;
     private final Map<Word<I>, List<D>> rows;
     private final List<Word<I>> suffixes;
 
-    LLambdaState(Set<Word<I>> shortPrefixes, Map<Word<I>, List<D>> rows, List<Word<I>> suffixes) {
+    LLambdaState(Alphabet<I> alphabet, Set<Word<I>> shortPrefixes, Map<Word<I>, List<D>> rows, List<Word<I>> suffixes) {
+        this.alphabet = alphabet;
         this.shortPrefixes = shortPrefixes;
         this.rows = rows;
         this.suffixes = suffixes;
+    }
+
+    Alphabet<I> getAlphabet() {
+        return alphabet;
     }
 
     Set<Word<I>> getShortPrefixes() {

--- a/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/AbstractTTTLambda.java
+++ b/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/AbstractTTTLambda.java
@@ -20,6 +20,7 @@ import java.util.Deque;
 import java.util.List;
 import java.util.Objects;
 
+import de.learnlib.Resumable;
 import de.learnlib.algorithm.LearningAlgorithm;
 import de.learnlib.algorithm.lambda.ttt.dt.AbstractDecisionTree;
 import de.learnlib.algorithm.lambda.ttt.dt.DTLeaf;
@@ -36,13 +37,15 @@ import net.automatalib.automaton.concept.SuffixOutput;
 import net.automatalib.word.Word;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-public abstract class AbstractTTTLambda<M extends SuffixOutput<I, D>, I, D>
-        implements LearningAlgorithm<M, I, D>, SupportsGrowingAlphabet<I>, FiniteRepresentation {
+public abstract class AbstractTTTLambda<M extends SuffixOutput<I, D>, I, D> implements LearningAlgorithm<M, I, D>,
+                                                                                       SupportsGrowingAlphabet<I>,
+                                                                                       Resumable<TTTLambdaState<I, D>>,
+                                                                                       FiniteRepresentation {
 
     private final MembershipOracle<I, D> ceqs;
     protected final Alphabet<I> alphabet;
-    protected final SuffixTrie<I> strie;
-    protected final PrefixTree<I, D> ptree;
+    protected SuffixTrie<I> strie;
+    protected PrefixTree<I, D> ptree;
 
     protected AbstractTTTLambda(Alphabet<I> alphabet, MembershipOracle<I, D> ceqs) {
         this.alphabet = alphabet;
@@ -182,5 +185,16 @@ public abstract class AbstractTTTLambda<M extends SuffixOutput<I, D>, I, D>
         witnesses.push(new DefaultQuery<>(ua.word(), sprime));
 
         ua.makeShortPrefix();
+    }
+
+    @Override
+    public TTTLambdaState<I, D> suspend() {
+        return new TTTLambdaState<>(strie, ptree, dtree());
+    }
+
+    @Override
+    public void resume(TTTLambdaState<I, D> state) {
+        this.strie = state.strie;
+        this.ptree = state.ptree;
     }
 }

--- a/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/AbstractTTTLambda.java
+++ b/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/AbstractTTTLambda.java
@@ -27,6 +27,7 @@ import de.learnlib.algorithm.lambda.ttt.dt.DTLeaf;
 import de.learnlib.algorithm.lambda.ttt.pt.PTNode;
 import de.learnlib.algorithm.lambda.ttt.pt.PrefixTree;
 import de.learnlib.algorithm.lambda.ttt.st.SuffixTrie;
+import de.learnlib.logging.Category;
 import de.learnlib.oracle.MembershipOracle;
 import de.learnlib.query.DefaultQuery;
 import de.learnlib.util.MQUtil;
@@ -36,11 +37,15 @@ import net.automatalib.automaton.concept.FiniteRepresentation;
 import net.automatalib.automaton.concept.SuffixOutput;
 import net.automatalib.word.Word;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class AbstractTTTLambda<M extends SuffixOutput<I, D>, I, D> implements LearningAlgorithm<M, I, D>,
                                                                                        SupportsGrowingAlphabet<I>,
                                                                                        Resumable<TTTLambdaState<I, D>>,
                                                                                        FiniteRepresentation {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractTTTLambda.class);
 
     private final MembershipOracle<I, D> mqs;
     private final MembershipOracle<I, D> ceqs;
@@ -198,5 +203,13 @@ public abstract class AbstractTTTLambda<M extends SuffixOutput<I, D>, I, D> impl
     public void resume(TTTLambdaState<I, D> state) {
         this.strie = state.strie;
         this.ptree = state.ptree;
+
+        final Alphabet<I> oldAlphabet = state.dtree.getAlphabet();
+        if (!this.alphabet.equals(oldAlphabet)) {
+            LOGGER.warn(Category.DATASTRUCTURE,
+                        "The current alphabet '{}' differs from the resumed alphabet '{}'. Future behavior may be inconsistent",
+                        this.alphabet,
+                        oldAlphabet);
+        }
     }
 }

--- a/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/AbstractTTTLambda.java
+++ b/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/AbstractTTTLambda.java
@@ -42,13 +42,15 @@ public abstract class AbstractTTTLambda<M extends SuffixOutput<I, D>, I, D> impl
                                                                                        Resumable<TTTLambdaState<I, D>>,
                                                                                        FiniteRepresentation {
 
+    private final MembershipOracle<I, D> mqs;
     private final MembershipOracle<I, D> ceqs;
     protected final Alphabet<I> alphabet;
     protected SuffixTrie<I> strie;
     protected PrefixTree<I, D> ptree;
 
-    protected AbstractTTTLambda(Alphabet<I> alphabet, MembershipOracle<I, D> ceqs) {
+    protected AbstractTTTLambda(Alphabet<I> alphabet, MembershipOracle<I, D> mqs, MembershipOracle<I, D> ceqs) {
         this.alphabet = alphabet;
+        this.mqs = mqs;
         this.ceqs = ceqs;
 
         this.strie = new SuffixTrie<>();
@@ -64,8 +66,8 @@ public abstract class AbstractTTTLambda<M extends SuffixOutput<I, D>, I, D> impl
     @Override
     public void startLearning() {
         assert dtree() != null && getHypothesisModel() != null;
-        dtree().sift(ptree.root());
-        makeConsistent();
+        dtree().sift(mqs, ptree.root());
+        makeConsistent(mqs);
     }
 
     @Override
@@ -85,7 +87,7 @@ public abstract class AbstractTTTLambda<M extends SuffixOutput<I, D>, I, D> impl
 
             if (valid) {
                 analyzeCounterexample(witness, witnesses);
-                makeConsistent();
+                makeConsistent(mqs);
                 refined = true;
             } else {
                 witnesses.pop();
@@ -112,15 +114,15 @@ public abstract class AbstractTTTLambda<M extends SuffixOutput<I, D>, I, D> impl
                 assert u != null;
                 PTNode<I, D> ua = u.append(symbol);
                 assert ua != null;
-                dtree().sift(ua);
+                dtree().sift(mqs, ua);
             }
 
-            makeConsistent();
+            makeConsistent(mqs);
         }
     }
 
-    protected void makeConsistent() {
-        while (dtree().makeConsistent()) {
+    protected void makeConsistent(MembershipOracle<I, D> oracle) {
+        while (dtree().makeConsistent(oracle)) {
             // do nothing ...
         }
     }
@@ -184,7 +186,7 @@ public abstract class AbstractTTTLambda<M extends SuffixOutput<I, D>, I, D> impl
         }
         witnesses.push(new DefaultQuery<>(ua.word(), sprime));
 
-        ua.makeShortPrefix();
+        ua.makeShortPrefix(mqs);
     }
 
     @Override

--- a/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/TTTLambdaState.java
+++ b/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/TTTLambdaState.java
@@ -1,0 +1,33 @@
+/* Copyright (C) 2013-2026 TU Dortmund University
+ * This file is part of LearnLib <https://learnlib.de>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.learnlib.algorithm.lambda.ttt;
+
+import de.learnlib.algorithm.lambda.ttt.dt.AbstractDecisionTree;
+import de.learnlib.algorithm.lambda.ttt.pt.PrefixTree;
+import de.learnlib.algorithm.lambda.ttt.st.SuffixTrie;
+
+public class TTTLambdaState<I, D> {
+
+    public final SuffixTrie<I> strie;
+    public final PrefixTree<I, D> ptree;
+    public final AbstractDecisionTree<I, D> dtree;
+
+    public TTTLambdaState(SuffixTrie<I> strie, PrefixTree<I, D> ptree, AbstractDecisionTree<I, D> dtree) {
+        this.strie = strie;
+        this.ptree = ptree;
+        this.dtree = dtree;
+    }
+}

--- a/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/dfa/DecisionTreeDFA.java
+++ b/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/dfa/DecisionTreeDFA.java
@@ -20,15 +20,13 @@ import de.learnlib.algorithm.lambda.ttt.dt.AbstractDecisionTree;
 import de.learnlib.algorithm.lambda.ttt.dt.Children;
 import de.learnlib.algorithm.lambda.ttt.dt.DTInnerNode;
 import de.learnlib.algorithm.lambda.ttt.dt.DTLeaf;
-import de.learnlib.algorithm.lambda.ttt.pt.PTNode;
 import de.learnlib.algorithm.lambda.ttt.st.STNode;
-import de.learnlib.oracle.MembershipOracle;
 import net.automatalib.alphabet.Alphabet;
 
 class DecisionTreeDFA<I> extends AbstractDecisionTree<I, Boolean> {
 
-    DecisionTreeDFA(MembershipOracle<I, Boolean> mqOracle, Alphabet<I> sigma, STNode<I> stRoot) {
-        super(sigma, mqOracle, stRoot);
+    DecisionTreeDFA(Alphabet<I> sigma, STNode<I> stRoot) {
+        super(sigma, stRoot);
     }
 
     boolean isAccepting(DTLeaf<I, Boolean> s) {
@@ -39,11 +37,6 @@ class DecisionTreeDFA<I> extends AbstractDecisionTree<I, Boolean> {
     @Override
     protected Children<I, Boolean> newChildren() {
         return new ChildrenDFA<>();
-    }
-
-    @Override
-    protected Boolean query(PTNode<I, Boolean> prefix, STNode<I> suffix) {
-        return mqOracle.answerQuery(prefix.word(), suffix.word());
     }
 
     private DTInnerNode<I, Boolean> localRoot() {

--- a/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/dfa/TTTLambdaDFA.java
+++ b/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/dfa/TTTLambdaDFA.java
@@ -17,6 +17,7 @@ package de.learnlib.algorithm.lambda.ttt.dfa;
 
 import de.learnlib.algorithm.LearningAlgorithm.DFALearner;
 import de.learnlib.algorithm.lambda.ttt.AbstractTTTLambda;
+import de.learnlib.algorithm.lambda.ttt.TTTLambdaState;
 import de.learnlib.algorithm.lambda.ttt.dt.AbstractDecisionTree;
 import de.learnlib.algorithm.lambda.ttt.dt.DTInnerNode;
 import de.learnlib.algorithm.lambda.ttt.dt.DTLeaf;
@@ -28,8 +29,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class TTTLambdaDFA<I> extends AbstractTTTLambda<DFA<?, I>, I, Boolean> implements DFALearner<I> {
 
-    private final HypothesisDFA<I> hypothesis;
-    private final DecisionTreeDFA<I> dtree;
+    private HypothesisDFA<I> hypothesis;
+    private DecisionTreeDFA<I> dtree;
 
     public TTTLambdaDFA(Alphabet<I> alphabet, MembershipOracle<I, Boolean> mqo) {
         this(alphabet, mqo, mqo);
@@ -66,5 +67,16 @@ public class TTTLambdaDFA<I> extends AbstractTTTLambda<DFA<?, I>, I, Boolean> im
     @Override
     public int size() {
         return hypothesis.size();
+    }
+
+    @Override
+    public void resume(TTTLambdaState<I, Boolean> state) {
+        super.resume(state);
+        if (state.dtree instanceof DecisionTreeDFA<I> d) {
+            this.dtree = d;
+            this.hypothesis = new HypothesisDFA<>(ptree, dtree);
+        } else {
+            throw new IllegalArgumentException("provided state does not match expected structure");
+        }
     }
 }

--- a/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/dfa/TTTLambdaDFA.java
+++ b/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/dfa/TTTLambdaDFA.java
@@ -37,8 +37,8 @@ public class TTTLambdaDFA<I> extends AbstractTTTLambda<DFA<?, I>, I, Boolean> im
     }
 
     public TTTLambdaDFA(Alphabet<I> alphabet, MembershipOracle<I, Boolean> mqs, MembershipOracle<I, Boolean> ceqs) {
-        super(alphabet, ceqs);
-        dtree = new DecisionTreeDFA<>(mqs, alphabet, strie.root());
+        super(alphabet, mqs, ceqs);
+        dtree = new DecisionTreeDFA<>(alphabet, strie.root());
         DTInnerNode<I, Boolean> dtRoot = new DTInnerNode<>(null, dtree, new ChildrenDFA<>(), strie.root());
         dtree.setRoot(dtRoot);
         hypothesis = new HypothesisDFA<>(ptree, dtree);

--- a/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/dt/AbstractDTNode.java
+++ b/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/dt/AbstractDTNode.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import de.learnlib.algorithm.lambda.ttt.pt.PTNode;
+import de.learnlib.oracle.MembershipOracle;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public abstract class AbstractDTNode<I, D> {
@@ -44,7 +45,7 @@ public abstract class AbstractDTNode<I, D> {
         }
     }
 
-    abstract void sift(PTNode<I, D> prefix);
+    abstract void sift(MembershipOracle<I, D> oracle, PTNode<I, D> prefix);
 
     abstract void leaves(List<DTLeaf<I, D>> list);
 

--- a/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/dt/AbstractDecisionTree.java
+++ b/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/dt/AbstractDecisionTree.java
@@ -26,23 +26,19 @@ import net.automatalib.alphabet.Alphabet;
 public abstract class AbstractDecisionTree<I, D> {
 
     private final STNode<I> stRoot;
-    protected final MembershipOracle<I, D> mqOracle;
-    protected final Alphabet<I> alphabet;
+    private final Alphabet<I> alphabet;
 
     protected AbstractDTNode<I, D> root;
 
-    protected AbstractDecisionTree(Alphabet<I> alphabet, MembershipOracle<I, D> mqOracle, STNode<I> stRoot) {
-        this.mqOracle = mqOracle;
+    protected AbstractDecisionTree(Alphabet<I> alphabet, STNode<I> stRoot) {
         this.alphabet = alphabet;
         this.stRoot = stRoot;
     }
 
     protected abstract Children<I, D> newChildren();
 
-    protected abstract D query(PTNode<I, D> prefix, STNode<I> suffix);
-
-    public void sift(PTNode<I, D> prefix) {
-        root.sift(prefix);
+    public void sift(MembershipOracle<I, D> oracle, PTNode<I, D> prefix) {
+        root.sift(oracle, prefix);
     }
 
     public void setRoot(AbstractDTNode<I, D> newRoot) {
@@ -55,11 +51,11 @@ public abstract class AbstractDecisionTree<I, D> {
         return list;
     }
 
-    public boolean makeConsistent() {
+    public boolean makeConsistent(MembershipOracle<I, D> oracle) {
         List<DTLeaf<I, D>> leaves = new ArrayList<>();
         root.leaves(leaves);
         for (DTLeaf<I, D> n : leaves) {
-            if (n.refineIfPossible()) {
+            if (n.refineIfPossible(oracle)) {
                 return true;
             }
         }
@@ -70,7 +66,7 @@ public abstract class AbstractDecisionTree<I, D> {
         return root;
     }
 
-    Alphabet<I> getAlphabet() {
+    public Alphabet<I> getAlphabet() {
         return alphabet;
     }
 

--- a/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/dt/DTInnerNode.java
+++ b/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/dt/DTInnerNode.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import de.learnlib.algorithm.lambda.ttt.pt.PTNode;
 import de.learnlib.algorithm.lambda.ttt.st.STNode;
+import de.learnlib.oracle.MembershipOracle;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class DTInnerNode<I, D> extends AbstractDTNode<I, D> {
@@ -40,11 +41,11 @@ public class DTInnerNode<I, D> extends AbstractDTNode<I, D> {
     }
 
     @Override
-    void sift(PTNode<I, D> prefix) {
-        D out = tree.query(prefix, suffix);
+    void sift(MembershipOracle<I, D> oracle, PTNode<I, D> prefix) {
+        D out = oracle.answerQuery(prefix.word(), suffix.word());
         AbstractDTNode<I, D> succ = children.child(out);
         if (succ != null) {
-            succ.sift(prefix);
+            succ.sift(oracle, prefix);
         } else {
             DTLeaf<I, D> newLeaf = new DTLeaf<>(this, tree, prefix);
             children.addChild(out, newLeaf);
@@ -52,7 +53,7 @@ public class DTInnerNode<I, D> extends AbstractDTNode<I, D> {
 
             for (I a : tree.getAlphabet()) {
                 PTNode<I, D> ua = prefix.append(a);
-                tree.root().sift(ua);
+                tree.root().sift(oracle, ua);
             }
         }
     }

--- a/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/dt/DTLeaf.java
+++ b/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/dt/DTLeaf.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import de.learnlib.algorithm.lambda.ttt.pt.PTNode;
 import de.learnlib.algorithm.lambda.ttt.st.STNode;
+import de.learnlib.oracle.MembershipOracle;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class DTLeaf<I, D> extends AbstractDTNode<I, D> {
@@ -46,7 +47,7 @@ public class DTLeaf<I, D> extends AbstractDTNode<I, D> {
     }
 
     @Override
-    void sift(PTNode<I, D> prefix) {
+    void sift(MembershipOracle<I, D> oracle, PTNode<I, D> prefix) {
         prefix.setState(this);
         this.longPrefixes.add(prefix);
     }
@@ -56,17 +57,17 @@ public class DTLeaf<I, D> extends AbstractDTNode<I, D> {
         list.add(this);
     }
 
-    public boolean refineIfPossible() {
+    public boolean refineIfPossible(MembershipOracle<I, D> oracle) {
         PTNode<I, D> ref = shortPrefixes.get(0);
         for (int i = 1; i < shortPrefixes.size(); i++) {
-            if (refineIfPossible(ref, shortPrefixes.get(i))) {
+            if (refineIfPossible(oracle, ref, shortPrefixes.get(i))) {
                 return true;
             }
         }
         return false;
     }
 
-    private boolean refineIfPossible(PTNode<I, D> u1, PTNode<I, D> u2) {
+    private boolean refineIfPossible(MembershipOracle<I, D> oracle, PTNode<I, D> u1, PTNode<I, D> u2) {
         I bestA = null;
         int vLength = 0;
         for (I a : tree.getAlphabet()) {
@@ -85,13 +86,13 @@ public class DTLeaf<I, D> extends AbstractDTNode<I, D> {
             }
         }
         if (bestA != null) {
-            split(u1, u2, bestA);
+            split(oracle, u1, u2, bestA);
             return true;
         }
         return false;
     }
 
-    public void makeShortPrefix(PTNode<I, D> uNew) {
+    public void makeShortPrefix(MembershipOracle<I, D> oracle, PTNode<I, D> uNew) {
         assert !shortPrefixes.contains(uNew);
         assert longPrefixes.contains(uNew);
         longPrefixes.remove(uNew);
@@ -99,11 +100,11 @@ public class DTLeaf<I, D> extends AbstractDTNode<I, D> {
 
         for (I a : tree.getAlphabet()) {
             PTNode<I, D> ua = uNew.append(a);
-            tree.root().sift(ua);
+            tree.root().sift(oracle, ua);
         }
     }
 
-    public void split(PTNode<I, D> u1, PTNode<I, D> u2, I a) {
+    public void split(MembershipOracle<I, D> oracle, PTNode<I, D> u1, PTNode<I, D> u2, I a) {
         PTNode<I, D> s1 = u1.succ(a);
         PTNode<I, D> s2 = u2.succ(a);
         assert s1 != null && s2 != null;
@@ -123,7 +124,7 @@ public class DTLeaf<I, D> extends AbstractDTNode<I, D> {
 
         for (PTNode<I, D> uOther : shortPrefixes) {
             // FIXME: We could safe some queries here in the dfa case ...
-            D out = tree.query(uOther, av);
+            D out = oracle.answerQuery(uOther.word(), av.word());
             DTLeaf<I, D> leaf = newLeaves.get(out);
             if (leaf == null) {
                 leaf = new DTLeaf<>(newInner, tree, uOther);
@@ -145,7 +146,7 @@ public class DTLeaf<I, D> extends AbstractDTNode<I, D> {
         }
 
         for (PTNode<I, D> ua : longPrefixes) {
-            newInner.sift(ua);
+            newInner.sift(oracle, ua);
         }
 
     }

--- a/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/mealy/DecisionTreeMealy.java
+++ b/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/mealy/DecisionTreeMealy.java
@@ -34,8 +34,8 @@ class DecisionTreeMealy<I, O> extends AbstractDecisionTree<I, Word<O>> {
 
     private final Map<Word<I>, O> outputs;
 
-    DecisionTreeMealy(MembershipOracle<I, Word<O>> mqOracle, Alphabet<I> sigma, STNode<I> stRoot) {
-        super(sigma, mqOracle, stRoot);
+    DecisionTreeMealy(Alphabet<I> sigma, STNode<I> stRoot) {
+        super(sigma, stRoot);
         this.outputs = new HashMap<>();
     }
 
@@ -44,43 +44,38 @@ class DecisionTreeMealy<I, O> extends AbstractDecisionTree<I, Word<O>> {
         return new ChildrenMealy<>();
     }
 
-    @Override
-    protected Word<O> query(PTNode<I, Word<O>> prefix, STNode<I> suffix) {
-        return mqOracle.answerQuery(prefix.word(), suffix.word());
-    }
-
-    O getOutput(DTLeaf<I, Word<O>> leaf, I a) {
-        return lookupOrQuery(leaf.getShortPrefixes().get(0).word(), a);
+    O getOutput(MembershipOracle<I, Word<O>> oracle, DTLeaf<I, Word<O>> leaf, I a) {
+        return lookupOrQuery(oracle, leaf.getShortPrefixes().get(0).word(), a);
     }
 
     @Override
-    public boolean makeConsistent() {
+    public boolean makeConsistent(MembershipOracle<I, Word<O>> oracle) {
         for (DTLeaf<I, Word<O>> n : leaves()) {
             if (n.getShortPrefixes().size() < 2) {
                 continue;
             }
-            for (I a : alphabet) {
+            for (I a : getAlphabet()) {
                 O refOut = null;
                 List<PTNode<I, Word<O>>> sp = new LinkedList<>(n.getShortPrefixes());
                 for (PTNode<I, Word<O>> u : sp) {
-                    O out = lookupOrQuery(u.word(), a);
+                    O out = lookupOrQuery(oracle, u.word(), a);
                     if (refOut == null) {
                         refOut = out;
                     } else if (!Objects.equals(refOut, out)) {
-                        n.split(sp.get(0), u, a);
+                        n.split(oracle, sp.get(0), u, a);
                         return true;
                     }
                 }
             }
         }
-        return super.makeConsistent();
+        return super.makeConsistent(oracle);
     }
 
-    private O lookupOrQuery(Word<I> prefix, I step) {
+    private O lookupOrQuery(MembershipOracle<I, Word<O>> oracle, Word<I> prefix, I step) {
         Word<I> lookup = prefix.append(step);
         O out = this.outputs.get(lookup);
         if (out == null) {
-            out = mqOracle.answerQuery(prefix, Word.fromLetter(step)).lastSymbol();
+            out = oracle.answerQuery(prefix, Word.fromLetter(step)).lastSymbol();
             this.outputs.put(lookup, out);
         }
         return out;

--- a/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/mealy/HypothesisMealy.java
+++ b/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/mealy/HypothesisMealy.java
@@ -20,16 +20,19 @@ import java.util.Collection;
 import de.learnlib.algorithm.lambda.ttt.dt.DTLeaf;
 import de.learnlib.algorithm.lambda.ttt.pt.PTNode;
 import de.learnlib.algorithm.lambda.ttt.pt.PrefixTree;
+import de.learnlib.oracle.MembershipOracle;
 import net.automatalib.alphabet.Alphabet;
 import net.automatalib.automaton.transducer.MealyMachine;
 import net.automatalib.word.Word;
 
 class HypothesisMealy<I, O> implements MealyMachine<DTLeaf<I, Word<O>>, I, MealyTransition<I, O>, O> {
 
+    private final MembershipOracle<I, Word<O>> oracle;
     private final PrefixTree<I, Word<O>> ptree;
     private final DecisionTreeMealy<I, O> dtree;
 
-    HypothesisMealy(PrefixTree<I, Word<O>> ptree, DecisionTreeMealy<I, O> dtree) {
+    HypothesisMealy(MembershipOracle<I, Word<O>> oracle, PrefixTree<I, Word<O>> ptree, DecisionTreeMealy<I, O> dtree) {
+        this.oracle = oracle;
         this.ptree = ptree;
         this.dtree = dtree;
     }
@@ -41,7 +44,7 @@ class HypothesisMealy<I, O> implements MealyMachine<DTLeaf<I, Word<O>>, I, Mealy
 
     @Override
     public O getTransitionOutput(MealyTransition<I, O> o) {
-        return dtree.getOutput(o.source, o.input);
+        return dtree.getOutput(oracle, o.source, o.input);
     }
 
     @Override
@@ -75,7 +78,7 @@ class HypothesisMealy<I, O> implements MealyMachine<DTLeaf<I, Word<O>>, I, Mealy
     void fetchAllPendingOutputs(Alphabet<I> alphabet) {
         for (DTLeaf<I, Word<O>> s : dtree.leaves()) {
             for (I i : alphabet) {
-                dtree.getOutput(s, i);
+                dtree.getOutput(oracle, s, i);
             }
         }
     }

--- a/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/mealy/TTTLambdaMealy.java
+++ b/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/mealy/TTTLambdaMealy.java
@@ -29,6 +29,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class TTTLambdaMealy<I, O> extends AbstractTTTLambda<MealyMachine<?, I, ?, O>, I, Word<O>>
         implements MealyLearner<I, O> {
 
+    private final MembershipOracle<I, Word<O>> mqs;
     private HypothesisMealy<I, O> hypothesis;
     private DecisionTreeMealy<I, O> dtree;
 
@@ -37,15 +38,16 @@ public class TTTLambdaMealy<I, O> extends AbstractTTTLambda<MealyMachine<?, I, ?
     }
 
     public TTTLambdaMealy(Alphabet<I> alphabet, MembershipOracle<I, Word<O>> mqs, MembershipOracle<I, Word<O>> ceqs) {
-        super(alphabet, ceqs);
-        dtree = new DecisionTreeMealy<>(mqs, alphabet, strie.root());
+        super(alphabet, mqs, ceqs);
+        dtree = new DecisionTreeMealy<>(alphabet, strie.root());
         DTLeaf<I, Word<O>> dtRoot = new DTLeaf<>(null, dtree, ptree.root());
         dtree.setRoot(dtRoot);
         ptree.root().setState(dtRoot);
         for (I a : alphabet) {
-            dtree.sift(ptree.root().append(a));
+            dtree.sift(mqs, ptree.root().append(a));
         }
-        hypothesis = new HypothesisMealy<>(ptree, dtree);
+        this.mqs = mqs;
+        hypothesis = new HypothesisMealy<>(mqs, ptree, dtree);
     }
 
     @Override
@@ -74,8 +76,8 @@ public class TTTLambdaMealy<I, O> extends AbstractTTTLambda<MealyMachine<?, I, ?
     }
 
     @Override
-    protected void makeConsistent() {
-        super.makeConsistent();
+    protected void makeConsistent(MembershipOracle<I, Word<O>> oracle) {
+        super.makeConsistent(oracle);
         hypothesis.fetchAllPendingOutputs(super.alphabet);
     }
 
@@ -84,7 +86,7 @@ public class TTTLambdaMealy<I, O> extends AbstractTTTLambda<MealyMachine<?, I, ?
         super.resume(state);
         if (state.dtree instanceof DecisionTreeMealy<I, O> d) {
             this.dtree = d;
-            this.hypothesis = new HypothesisMealy<>(ptree, dtree);
+            this.hypothesis = new HypothesisMealy<>(mqs, ptree, dtree);
         } else {
             throw new IllegalArgumentException("provided state does not match expected structure");
         }

--- a/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/mealy/TTTLambdaMealy.java
+++ b/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/mealy/TTTLambdaMealy.java
@@ -17,6 +17,7 @@ package de.learnlib.algorithm.lambda.ttt.mealy;
 
 import de.learnlib.algorithm.LearningAlgorithm.MealyLearner;
 import de.learnlib.algorithm.lambda.ttt.AbstractTTTLambda;
+import de.learnlib.algorithm.lambda.ttt.TTTLambdaState;
 import de.learnlib.algorithm.lambda.ttt.dt.AbstractDecisionTree;
 import de.learnlib.algorithm.lambda.ttt.dt.DTLeaf;
 import de.learnlib.oracle.MembershipOracle;
@@ -28,8 +29,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class TTTLambdaMealy<I, O> extends AbstractTTTLambda<MealyMachine<?, I, ?, O>, I, Word<O>>
         implements MealyLearner<I, O> {
 
-    private final HypothesisMealy<I, O> hypothesis;
-    private final DecisionTreeMealy<I, O> dtree;
+    private HypothesisMealy<I, O> hypothesis;
+    private DecisionTreeMealy<I, O> dtree;
 
     public TTTLambdaMealy(Alphabet<I> alphabet, MembershipOracle<I, Word<O>> mqo) {
         this(alphabet, mqo, mqo);
@@ -76,5 +77,16 @@ public class TTTLambdaMealy<I, O> extends AbstractTTTLambda<MealyMachine<?, I, ?
     protected void makeConsistent() {
         super.makeConsistent();
         hypothesis.fetchAllPendingOutputs(super.alphabet);
+    }
+
+    @Override
+    public void resume(TTTLambdaState<I, Word<O>> state) {
+        super.resume(state);
+        if (state.dtree instanceof DecisionTreeMealy<I, O> d) {
+            this.dtree = d;
+            this.hypothesis = new HypothesisMealy<>(ptree, dtree);
+        } else {
+            throw new IllegalArgumentException("provided state does not match expected structure");
+        }
     }
 }

--- a/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/pt/PTNode.java
+++ b/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/pt/PTNode.java
@@ -16,6 +16,7 @@
 package de.learnlib.algorithm.lambda.ttt.pt;
 
 import de.learnlib.algorithm.lambda.ttt.dt.DTLeaf;
+import de.learnlib.oracle.MembershipOracle;
 import net.automatalib.word.Word;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -31,5 +32,5 @@ public interface PTNode<I, D> {
 
     @Nullable PTNode<I, D> succ(I a);
 
-    void makeShortPrefix();
+    void makeShortPrefix(MembershipOracle<I, D> oracle);
 }

--- a/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/pt/PTNodeImpl.java
+++ b/algorithms/active/lambda/src/main/java/de/learnlib/algorithm/lambda/ttt/pt/PTNodeImpl.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import de.learnlib.algorithm.lambda.ttt.dt.DTLeaf;
+import de.learnlib.oracle.MembershipOracle;
 import net.automatalib.word.Word;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -72,8 +73,8 @@ public class PTNodeImpl<I, D> implements PTNode<I, D> {
     }
 
     @Override
-    public void makeShortPrefix() {
-        this.state.makeShortPrefix(this);
+    public void makeShortPrefix(MembershipOracle<I, D> oracle) {
+        this.state.makeShortPrefix(oracle, this);
     }
 }
 

--- a/algorithms/active/lambda/src/main/java/module-info.java
+++ b/algorithms/active/lambda/src/main/java/module-info.java
@@ -35,6 +35,7 @@ open module de.learnlib.algorithm.lambda {
     requires net.automatalib.api;
     requires net.automatalib.common.util;
     requires net.automatalib.core;
+    requires org.slf4j;
 
     // annotations are 'provided'-scoped and do not need to be loaded at runtime
     requires static org.checkerframework.checker.qual;

--- a/algorithms/active/lambda/src/test/java/de/learnlib/algorithm/lambda/ttt/dfa/TTTLambdaDFAResumableTest.java
+++ b/algorithms/active/lambda/src/test/java/de/learnlib/algorithm/lambda/ttt/dfa/TTTLambdaDFAResumableTest.java
@@ -1,0 +1,35 @@
+/* Copyright (C) 2013-2026 TU Dortmund University
+ * This file is part of LearnLib <https://learnlib.de>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.learnlib.algorithm.lambda.ttt.dfa;
+
+import de.learnlib.algorithm.lambda.ttt.TTTLambdaState;
+import de.learnlib.oracle.MembershipOracle.DFAMembershipOracle;
+import de.learnlib.testsupport.AbstractResumableLearnerDFATest;
+import net.automatalib.alphabet.Alphabet;
+
+public class TTTLambdaDFAResumableTest
+        extends AbstractResumableLearnerDFATest<TTTLambdaDFA<Character>, TTTLambdaState<Character, Boolean>> {
+
+    @Override
+    protected TTTLambdaDFA<Character> getLearner(DFAMembershipOracle<Character> oracle, Alphabet<Character> alphabet) {
+        return new TTTLambdaDFA<>(alphabet, oracle);
+    }
+
+    @Override
+    protected int getRounds() {
+        return 2;
+    }
+}

--- a/algorithms/active/lambda/src/test/java/de/learnlib/algorithm/lambda/ttt/dfa/TTTLambdaDFAResumableTest.java
+++ b/algorithms/active/lambda/src/test/java/de/learnlib/algorithm/lambda/ttt/dfa/TTTLambdaDFAResumableTest.java
@@ -16,9 +16,15 @@
 package de.learnlib.algorithm.lambda.ttt.dfa;
 
 import de.learnlib.algorithm.lambda.ttt.TTTLambdaState;
+import de.learnlib.algorithm.lambda.ttt.mealy.TTTLambdaMealy;
 import de.learnlib.oracle.MembershipOracle.DFAMembershipOracle;
+import de.learnlib.oracle.SingleQueryOracle;
 import de.learnlib.testsupport.AbstractResumableLearnerDFATest;
 import net.automatalib.alphabet.Alphabet;
+import net.automatalib.alphabet.impl.Alphabets;
+import net.automatalib.word.Word;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 public class TTTLambdaDFAResumableTest
         extends AbstractResumableLearnerDFATest<TTTLambdaDFA<Character>, TTTLambdaState<Character, Boolean>> {
@@ -31,5 +37,20 @@ public class TTTLambdaDFAResumableTest
     @Override
     protected int getRounds() {
         return 2;
+    }
+
+    @Test
+    public void testIncorrectState() {
+        final Alphabet<Character> alphabet = Alphabets.fromArray();
+        final SingleQueryOracle<Character, Word<Character>> oracleMealy = (pre, suff) -> suff;
+        final SingleQueryOracle<Character, Boolean> oracleDFA = (pre, suff) -> false;
+        final var learnerMealy = new TTTLambdaMealy<>(alphabet, oracleMealy);
+        final var learnerDFA = new TTTLambdaDFA<>(alphabet, oracleDFA);
+
+        final TTTLambdaState<?, ?> origState = learnerMealy.suspend();
+        @SuppressWarnings("unchecked")
+        final TTTLambdaState<Character, Boolean> castState = (TTTLambdaState<Character, Boolean>) origState;
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> learnerDFA.resume(castState));
     }
 }

--- a/algorithms/active/lambda/src/test/java/de/learnlib/algorithm/lambda/ttt/mealy/TTTLambdaMealyResumableTest.java
+++ b/algorithms/active/lambda/src/test/java/de/learnlib/algorithm/lambda/ttt/mealy/TTTLambdaMealyResumableTest.java
@@ -16,10 +16,15 @@
 package de.learnlib.algorithm.lambda.ttt.mealy;
 
 import de.learnlib.algorithm.lambda.ttt.TTTLambdaState;
+import de.learnlib.algorithm.lambda.ttt.dfa.TTTLambdaDFA;
 import de.learnlib.oracle.MembershipOracle.MealyMembershipOracle;
+import de.learnlib.oracle.SingleQueryOracle;
 import de.learnlib.testsupport.AbstractResumableLearnerMealyTest;
 import net.automatalib.alphabet.Alphabet;
+import net.automatalib.alphabet.impl.Alphabets;
 import net.automatalib.word.Word;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 public class TTTLambdaMealyResumableTest
         extends AbstractResumableLearnerMealyTest<TTTLambdaMealy<Character, Character>, TTTLambdaState<Character, Word<Character>>> {
@@ -33,5 +38,21 @@ public class TTTLambdaMealyResumableTest
     @Override
     protected int getRounds() {
         return 2;
+    }
+
+    @Test
+    public void testIncorrectState() {
+        final Alphabet<Character> alphabet = Alphabets.fromArray();
+        final SingleQueryOracle<Character, Word<Character>> oracleMealy = (pre, suff) -> suff;
+        final SingleQueryOracle<Character, Boolean> oracleDFA = (pre, suff) -> false;
+        final var learnerMealy = new TTTLambdaMealy<>(alphabet, oracleMealy);
+        final var learnerDFA = new TTTLambdaDFA<>(alphabet, oracleDFA);
+
+        final TTTLambdaState<?, ?> origState = learnerDFA.suspend();
+        @SuppressWarnings("unchecked")
+        final TTTLambdaState<Character, Word<Character>> castState =
+                (TTTLambdaState<Character, Word<Character>>) origState;
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> learnerMealy.resume(castState));
     }
 }

--- a/algorithms/active/lambda/src/test/java/de/learnlib/algorithm/lambda/ttt/mealy/TTTLambdaMealyResumableTest.java
+++ b/algorithms/active/lambda/src/test/java/de/learnlib/algorithm/lambda/ttt/mealy/TTTLambdaMealyResumableTest.java
@@ -1,0 +1,37 @@
+/* Copyright (C) 2013-2026 TU Dortmund University
+ * This file is part of LearnLib <https://learnlib.de>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.learnlib.algorithm.lambda.ttt.mealy;
+
+import de.learnlib.algorithm.lambda.ttt.TTTLambdaState;
+import de.learnlib.oracle.MembershipOracle.MealyMembershipOracle;
+import de.learnlib.testsupport.AbstractResumableLearnerMealyTest;
+import net.automatalib.alphabet.Alphabet;
+import net.automatalib.word.Word;
+
+public class TTTLambdaMealyResumableTest
+        extends AbstractResumableLearnerMealyTest<TTTLambdaMealy<Character, Character>, TTTLambdaState<Character, Word<Character>>> {
+
+    @Override
+    protected TTTLambdaMealy<Character, Character> getLearner(MealyMembershipOracle<Character, Character> oracle,
+                                                              Alphabet<Character> alphabet) {
+        return new TTTLambdaMealy<>(alphabet, oracle);
+    }
+
+    @Override
+    protected int getRounds() {
+        return 2;
+    }
+}


### PR DESCRIPTION
This PR adds `Resumable` support for the remaining lambda learner (`TTTLearner{DFA,Mealy}`). In particular, it removes the reference to membership oracles from internal data structure to not include them during serialization.

Closes #83.