### PR TITLE
Make L^s support growing alphabets

### DIFF
--- a/algorithms/active/aaar/pom.xml
+++ b/algorithms/active/aaar/pom.xml
@@ -98,6 +98,11 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>de.learnlib</groupId>
+            <artifactId>learnlib-sparse</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.learnlib</groupId>
             <artifactId>learnlib-ttt</artifactId>
             <scope>test</scope>
         </dependency>

--- a/algorithms/active/aaar/src/test/java/de/learnlib/algorithm/aaar/AAARTestUtil.java
+++ b/algorithms/active/aaar/src/test/java/de/learnlib/algorithm/aaar/AAARTestUtil.java
@@ -16,10 +16,8 @@
 package de.learnlib.algorithm.aaar;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
-import de.learnlib.acex.AcexAnalyzers;
 import de.learnlib.algorithm.LearningAlgorithm.DFALearner;
 import de.learnlib.algorithm.LearningAlgorithm.MealyLearner;
 import de.learnlib.algorithm.LearningAlgorithm.MooreLearner;
@@ -27,8 +25,6 @@ import de.learnlib.algorithm.kv.dfa.KearnsVaziraniDFA;
 import de.learnlib.algorithm.kv.mealy.KearnsVaziraniMealy;
 import de.learnlib.algorithm.lambda.ttt.dfa.TTTLambdaDFA;
 import de.learnlib.algorithm.lambda.ttt.mealy.TTTLambdaMealy;
-import de.learnlib.algorithm.lstar.ce.ObservationTableCEXHandlers;
-import de.learnlib.algorithm.lstar.closing.ClosingStrategies;
 import de.learnlib.algorithm.lstar.dfa.ClassicLStarDFA;
 import de.learnlib.algorithm.lstar.mealy.ExtensibleLStarMealy;
 import de.learnlib.algorithm.lstar.moore.ExtensibleLStarMoore;
@@ -38,10 +34,10 @@ import de.learnlib.algorithm.observationpack.moore.OPLearnerMoore;
 import de.learnlib.algorithm.rivestschapire.RivestSchapireDFA;
 import de.learnlib.algorithm.rivestschapire.RivestSchapireMealy;
 import de.learnlib.algorithm.rivestschapire.RivestSchapireMoore;
+import de.learnlib.algorithm.sparse.SparseLearner;
 import de.learnlib.algorithm.ttt.dfa.TTTLearnerDFA;
 import de.learnlib.algorithm.ttt.mealy.TTTLearnerMealy;
 import de.learnlib.algorithm.ttt.moore.TTTLearnerMoore;
-import de.learnlib.counterexample.LocalSuffixFinders;
 import net.automatalib.common.util.Pair;
 import net.automatalib.word.Word;
 
@@ -55,63 +51,46 @@ public final class AAARTestUtil {
 
         final ComboConstructor<ClassicLStarDFA<I>, I, Boolean> lstar = ClassicLStarDFA::new;
         final ComboConstructor<RivestSchapireDFA<I>, I, Boolean> rs = RivestSchapireDFA::new;
-        final ComboConstructor<KearnsVaziraniDFA<I>, I, Boolean> kv =
-                (alph, mqo) -> new KearnsVaziraniDFA<>(alph, mqo, true, AcexAnalyzers.BINARY_SEARCH_FWD);
-        final ComboConstructor<OPLearnerDFA<I>, I, Boolean> dt =
-                (alph, mqo) -> new OPLearnerDFA<>(alph, mqo, LocalSuffixFinders.RIVEST_SCHAPIRE, true, true);
-        final ComboConstructor<TTTLearnerDFA<I>, I, Boolean> ttt =
-                (alph, mqo) -> new TTTLearnerDFA<>(alph, mqo, AcexAnalyzers.BINARY_SEARCH_FWD);
-        final ComboConstructor<TTTLambdaDFA<I>, I, Boolean> lambda = (alph, mqo) -> new TTTLambdaDFA<>(alph, mqo, mqo);
+        final ComboConstructor<KearnsVaziraniDFA<I>, I, Boolean> kv = KearnsVaziraniDFA::new;
+        final ComboConstructor<OPLearnerDFA<I>, I, Boolean> op = OPLearnerDFA::new;
+        final ComboConstructor<TTTLearnerDFA<I>, I, Boolean> ttt = TTTLearnerDFA::new;
+        final ComboConstructor<TTTLambdaDFA<I>, I, Boolean> lambda = TTTLambdaDFA::new;
 
         return Arrays.asList(Pair.of("L*", lstar),
                              Pair.of("RS", rs),
                              Pair.of("KV", kv),
-                             Pair.of("DT", dt),
+                             Pair.of("OP", op),
                              Pair.of("TTT", ttt),
                              Pair.of("TTTLambda", lambda));
     }
 
     public static <I, O> List<Pair<String, ComboConstructor<? extends MealyLearner<I, O>, I, Word<O>>>> getMealyLearners() {
 
-        final ComboConstructor<ExtensibleLStarMealy<I, O>, I, Word<O>> lstar =
-                (alph, mqo) -> new ExtensibleLStarMealy<>(alph,
-                                                          mqo,
-                                                          Collections.emptyList(),
-                                                          ObservationTableCEXHandlers.CLASSIC_LSTAR,
-                                                          ClosingStrategies.CLOSE_FIRST);
+        final ComboConstructor<ExtensibleLStarMealy<I, O>, I, Word<O>> lstar = ExtensibleLStarMealy::new;
         final ComboConstructor<RivestSchapireMealy<I, O>, I, Word<O>> rs = RivestSchapireMealy::new;
-        final ComboConstructor<KearnsVaziraniMealy<I, O>, I, Word<O>> kv =
-                (alph, mqo) -> new KearnsVaziraniMealy<>(alph, mqo, true, AcexAnalyzers.BINARY_SEARCH_FWD);
-        final ComboConstructor<OPLearnerMealy<I, O>, I, Word<O>> dt =
-                (alph, mqo) -> new OPLearnerMealy<>(alph, mqo, LocalSuffixFinders.RIVEST_SCHAPIRE, true);
-        final ComboConstructor<TTTLearnerMealy<I, O>, I, Word<O>> ttt =
-                (alph, mqo) -> new TTTLearnerMealy<>(alph, mqo, AcexAnalyzers.BINARY_SEARCH_FWD);
-        final ComboConstructor<TTTLambdaMealy<I, O>, I, Word<O>> lambda =
-                (alph, mqo) -> new TTTLambdaMealy<>(alph, mqo, mqo);
+        final ComboConstructor<KearnsVaziraniMealy<I, O>, I, Word<O>> kv = KearnsVaziraniMealy::new;
+        final ComboConstructor<OPLearnerMealy<I, O>, I, Word<O>> op = OPLearnerMealy::new;
+        final ComboConstructor<SparseLearner<I, O>, I, Word<O>> sparse = SparseLearner::new;
+        final ComboConstructor<TTTLearnerMealy<I, O>, I, Word<O>> ttt = TTTLearnerMealy::new;
+        final ComboConstructor<TTTLambdaMealy<I, O>, I, Word<O>> lambda = TTTLambdaMealy::new;
 
         return Arrays.asList(Pair.of("L*", lstar),
                              Pair.of("RS", rs),
                              Pair.of("KV", kv),
-                             Pair.of("DT", dt),
+                             Pair.of("OP", op),
+                             Pair.of("Sparse", sparse),
                              Pair.of("TTT", ttt),
                              Pair.of("TTTLambda", lambda));
     }
 
     public static <I, O> List<Pair<String, ComboConstructor<? extends MooreLearner<I, O>, I, Word<O>>>> getMooreLearners() {
 
-        final ComboConstructor<ExtensibleLStarMoore<I, O>, I, Word<O>> lstar =
-                (alph, mqo) -> new ExtensibleLStarMoore<>(alph,
-                                                          mqo,
-                                                          Collections.emptyList(),
-                                                          ObservationTableCEXHandlers.CLASSIC_LSTAR,
-                                                          ClosingStrategies.CLOSE_FIRST);
+        final ComboConstructor<ExtensibleLStarMoore<I, O>, I, Word<O>> lstar = ExtensibleLStarMoore::new;
         final ComboConstructor<RivestSchapireMoore<I, O>, I, Word<O>> rs = RivestSchapireMoore::new;
-        final ComboConstructor<OPLearnerMoore<I, O>, I, Word<O>> dt =
-                (alph, mqo) -> new OPLearnerMoore<>(alph, mqo, LocalSuffixFinders.RIVEST_SCHAPIRE, true);
-        final ComboConstructor<TTTLearnerMoore<I, O>, I, Word<O>> ttt =
-                (alph, mqo) -> new TTTLearnerMoore<>(alph, mqo, AcexAnalyzers.BINARY_SEARCH_FWD);
+        final ComboConstructor<OPLearnerMoore<I, O>, I, Word<O>> op = OPLearnerMoore::new;
+        final ComboConstructor<TTTLearnerMoore<I, O>, I, Word<O>> ttt = TTTLearnerMoore::new;
 
-        return Arrays.asList(Pair.of("L*", lstar), Pair.of("RS", rs), Pair.of("DT", dt), Pair.of("TTT", ttt));
+        return Arrays.asList(Pair.of("L*", lstar), Pair.of("RS", rs), Pair.of("OP", op), Pair.of("TTT", ttt));
     }
 
 }

--- a/algorithms/active/procedural/pom.xml
+++ b/algorithms/active/procedural/pom.xml
@@ -100,6 +100,11 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>de.learnlib</groupId>
+            <artifactId>learnlib-sparse</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.learnlib</groupId>
             <artifactId>learnlib-ttt</artifactId>
             <scope>test</scope>
         </dependency>

--- a/algorithms/active/procedural/src/test/java/de/learnlib/algorithm/procedural/spmm/it/SPMMIT.java
+++ b/algorithms/active/procedural/src/test/java/de/learnlib/algorithm/procedural/spmm/it/SPMMIT.java
@@ -34,6 +34,7 @@ import de.learnlib.algorithm.procedural.spmm.SPMMLearner;
 import de.learnlib.algorithm.procedural.spmm.manager.DefaultATManager;
 import de.learnlib.algorithm.procedural.spmm.manager.OptimizingATManager;
 import de.learnlib.algorithm.rivestschapire.RivestSchapireMealy;
+import de.learnlib.algorithm.sparse.SparseLearner;
 import de.learnlib.algorithm.ttt.mealy.TTTLearnerMealy;
 import de.learnlib.oracle.MembershipOracle;
 import de.learnlib.oracle.MembershipOracle.MealyMembershipOracle;
@@ -61,6 +62,7 @@ public class SPMMIT extends AbstractSPMMLearnerIT {
         builder.addLearnerVariant(TTTLambdaMealy::new);
         builder.addLearnerVariant(RivestSchapireMealy::new);
         builder.addLearnerVariant(TTTLearnerMealy::new);
+        builder.addLearnerVariant(SparseLearner::new);
     }
 
     private static class Builder<I, O> {

--- a/algorithms/active/sparse/src/main/java/de/learnlib/algorithm/sparse/GenericSparseLearner.java
+++ b/algorithms/active/sparse/src/main/java/de/learnlib/algorithm/sparse/GenericSparseLearner.java
@@ -28,19 +28,21 @@ import java.util.function.Function;
 import de.learnlib.AccessSequenceTransformer;
 import de.learnlib.algorithm.LearningAlgorithm.MealyLearner;
 import de.learnlib.counterexample.LocalSuffixFinders;
-import de.learnlib.oracle.MembershipOracle.MealyMembershipOracle;
+import de.learnlib.oracle.MembershipOracle;
 import de.learnlib.query.DefaultQuery;
 import de.learnlib.util.mealy.MealyUtil;
 import net.automatalib.alphabet.Alphabet;
+import net.automatalib.alphabet.SupportsGrowingAlphabet;
 import net.automatalib.automaton.transducer.MealyMachine;
 import net.automatalib.automaton.transducer.MutableMealyMachine;
 import net.automatalib.common.util.Pair;
 import net.automatalib.word.Word;
 
-class GenericSparseLearner<S, I, O> implements MealyLearner<I, O>, AccessSequenceTransformer<I> {
+class GenericSparseLearner<M extends MutableMealyMachine<S, I, ?, O> & SupportsGrowingAlphabet<I>, S, I, O>
+        implements MealyLearner<I, O>, AccessSequenceTransformer<I>, SupportsGrowingAlphabet<I> {
 
     private final Alphabet<I> alphabet;
-    private final MealyMembershipOracle<I, O> oracle;
+    private final MembershipOracle<I, Word<O>> oracle;
 
     /**
      * Suffixes.
@@ -76,7 +78,7 @@ class GenericSparseLearner<S, I, O> implements MealyLearner<I, O>, AccessSequenc
     /**
      * Hypothesis.
      */
-    private final MutableMealyMachine<S, I, ?, O> hyp;
+    private final M hyp;
 
     /**
      * Maps each state to its core row prefix.
@@ -99,9 +101,9 @@ class GenericSparseLearner<S, I, O> implements MealyLearner<I, O>, AccessSequenc
     private final Map<Word<I>, Map<Word<O>, Integer>> sufToOutToIdx;
 
     protected GenericSparseLearner(Alphabet<I> alphabet,
-                                   MealyMembershipOracle<I, O> oracle,
+                                   MembershipOracle<I, Word<O>> oracle,
                                    List<Word<I>> initialSuffixes,
-                                   MutableMealyMachine<S, I, ?, O> emptyMachine) {
+                                   M emptyMachine) {
         this.alphabet = alphabet;
         this.oracle = oracle;
         sufs = new ArrayDeque<>(initialSuffixes);
@@ -131,7 +133,7 @@ class GenericSparseLearner<S, I, O> implements MealyLearner<I, O>, AccessSequenc
         cRows.add(c);
         sufs.forEach(s -> addSuffixToCoreRow(c, s));
         stateToPrefix.put(init, c.prefix);
-        extendFringe(c, init, new Leaf<>(c, 1, sufs.size(), Collections.emptyList()));
+        extendFringe(c, new Leaf<>(c, 1, sufs.size(), Collections.emptyList()));
         fRows.forEach(f -> query(f, Word.epsilon())); // query transition outputs
         // initially, transition outputs must be queried manually,
         // for later transitions, they derive from suffix queries
@@ -160,6 +162,26 @@ class GenericSparseLearner<S, I, O> implements MealyLearner<I, O>, AccessSequenc
     public Word<I> transformAccessSequence(Word<I> word) {
         requireLearningProcessStarted();
         return accSeq.apply(word);
+    }
+
+    @Override
+    public void addAlphabetSymbol(I i) {
+        if (!this.alphabet.containsSymbol(i)) {
+            this.alphabet.asGrowingAlphabetOrThrowException().addSymbol(i);
+        }
+
+        this.hyp.addAlphabetSymbol(i);
+
+        final Leaf<S, I, O> l = new Leaf<>();
+        for (CoreRow<S, I, O> c : cRows) {
+            addFringeRow(c, i, l);
+        }
+
+        // If the suffixes are empty, we have not started the learning process yet.
+        // In this case, treat the symbol as if it was part of the initial alphabet.
+        if (!this.hyp.getStates().isEmpty()) {
+            updateHypothesis();
+        }
     }
 
     private void updateHypothesis() {
@@ -303,7 +325,7 @@ class GenericSparseLearner<S, I, O> implements MealyLearner<I, O>, AccessSequenc
         }
 
         cRows.add(c);
-        extendFringe(c, state, new Leaf<>());
+        extendFringe(c, new Leaf<>());
         assert c.cellIds.size() == sufs.size();
         assert c == cRows.get(c.idx);
         return c.idx;
@@ -321,14 +343,20 @@ class GenericSparseLearner<S, I, O> implements MealyLearner<I, O>, AccessSequenc
         return cellIdsFull;
     }
 
-    private void extendFringe(CoreRow<S, I, O> c, S state, Leaf<S, I, O> leaf) {
+    /**
+     * Add missing fringe rows for new transitions.
+     */
+    private void extendFringe(CoreRow<S, I, O> c, Leaf<S, I, O> l) {
         for (I i : alphabet) {
-            // add missing fringe rows for new transitions
-            final Word<I> prefix = c.prefix.append(i);
-            final FringeRow<S, I, O> fRow = new FringeRow<>(prefix, state, leaf);
-            prefToFringe.put(prefix, fRow);
-            fRows.push(fRow); // prioritize new rows during classification
+            addFringeRow(c, i, l);
         }
+    }
+
+    private void addFringeRow(CoreRow<S, I, O> c, I i, Leaf<S, I, O> l) {
+        final Word<I> prefix = c.prefix.append(i);
+        final FringeRow<S, I, O> f = new FringeRow<>(prefix, c.state, l);
+        prefToFringe.put(prefix, f);
+        fRows.push(f); // prioritize new rows during classification
     }
 
     private void identifyNewState(DefaultQuery<I, Word<O>> q) {

--- a/algorithms/active/sparse/src/main/java/de/learnlib/algorithm/sparse/GenericSparseLearner.java
+++ b/algorithms/active/sparse/src/main/java/de/learnlib/algorithm/sparse/GenericSparseLearner.java
@@ -166,22 +166,25 @@ class GenericSparseLearner<M extends MutableMealyMachine<S, I, ?, O> & SupportsG
 
     @Override
     public void addAlphabetSymbol(I i) {
-        if (!this.alphabet.containsSymbol(i)) {
-            this.alphabet.asGrowingAlphabetOrThrowException().addSymbol(i);
+        alphabet.asGrowingAlphabetOrThrowException().addSymbol(i);
+        hyp.addAlphabetSymbol(i);
+        if (cRows.isEmpty()) {
+            return; // learning has not started yet
         }
 
-        this.hyp.addAlphabetSymbol(i);
-
-        final Leaf<S, I, O> l = new Leaf<>();
-        for (CoreRow<S, I, O> c : cRows) {
-            addFringeRow(c, i, l);
+        // add new fringe rows
+        if (cRows.size() == 1) {
+            // there is only a single state yet
+            final Leaf<S, I, O> l = fRows.getFirst().leaf;
+            assert l != null;
+            final FringeRow<S, I, O> f = addFringeRow(cRows.get(0), i, l);
+            query(f, Word.epsilon()); // for the first state, transition outputs must be queried manually
+        } else {
+            final Leaf<S, I, O> l = new Leaf<>(); // fringe rows that spawn together should share the same leaf
+            cRows.forEach(c -> addFringeRow(c, i, l));
         }
 
-        // If the suffixes are empty, we have not started the learning process yet.
-        // In this case, treat the symbol as if it was part of the initial alphabet.
-        if (!this.hyp.getStates().isEmpty()) {
-            updateHypothesis();
-        }
+        updateHypothesis();
     }
 
     private void updateHypothesis() {
@@ -344,7 +347,7 @@ class GenericSparseLearner<M extends MutableMealyMachine<S, I, ?, O> & SupportsG
     }
 
     /**
-     * Add missing fringe rows for new transitions.
+     * Add fringe rows for the transitions from a new core prefix.
      */
     private void extendFringe(CoreRow<S, I, O> c, Leaf<S, I, O> l) {
         for (I i : alphabet) {
@@ -352,11 +355,15 @@ class GenericSparseLearner<M extends MutableMealyMachine<S, I, ?, O> & SupportsG
         }
     }
 
-    private void addFringeRow(CoreRow<S, I, O> c, I i, Leaf<S, I, O> l) {
+    /**
+     * Creates a new fringe row and returns it after integrating it into the internal data structures.
+     */
+    private FringeRow<S, I, O> addFringeRow(CoreRow<S, I, O> c, I i, Leaf<S, I, O> l) {
         final Word<I> prefix = c.prefix.append(i);
         final FringeRow<S, I, O> f = new FringeRow<>(prefix, c.state, l);
         prefToFringe.put(prefix, f);
         fRows.push(f); // prioritize new rows during classification
+        return f;
     }
 
     private void identifyNewState(DefaultQuery<I, Word<O>> q) {

--- a/algorithms/active/sparse/src/main/java/de/learnlib/algorithm/sparse/SparseLearner.java
+++ b/algorithms/active/sparse/src/main/java/de/learnlib/algorithm/sparse/SparseLearner.java
@@ -18,7 +18,7 @@ package de.learnlib.algorithm.sparse;
 import java.util.Collections;
 import java.util.List;
 
-import de.learnlib.oracle.MembershipOracle.MealyMembershipOracle;
+import de.learnlib.oracle.MembershipOracle;
 import net.automatalib.alphabet.Alphabet;
 import net.automatalib.automaton.transducer.impl.CompactMealy;
 import net.automatalib.word.Word;
@@ -28,13 +28,13 @@ import net.automatalib.word.Word;
  * <a href="https://doi.org/10.1007/978-3-032-05792-1_10">Learning Mealy Machines with Sparse Observation Tables</a>
  * by Wolffhardt Schwabe, Paul Kogel, and Sabine Glesner.
  */
-public class SparseLearner<I, O> extends GenericSparseLearner<Integer, I, O> {
+public class SparseLearner<I, O> extends GenericSparseLearner<CompactMealy<I, O>, Integer, I, O> {
 
-    public SparseLearner(Alphabet<I> alphabet, MealyMembershipOracle<I, O> oracle) {
+    public SparseLearner(Alphabet<I> alphabet, MembershipOracle<I, Word<O>> oracle) {
         this(alphabet, oracle, Collections.emptyList());
     }
 
-    public SparseLearner(Alphabet<I> alphabet, MealyMembershipOracle<I, O> oracle, List<Word<I>> initialSuffixes) {
+    public SparseLearner(Alphabet<I> alphabet, MembershipOracle<I, Word<O>> oracle, List<Word<I>> initialSuffixes) {
         super(alphabet, oracle, initialSuffixes, new CompactMealy<>(alphabet));
     }
 }

--- a/algorithms/active/sparse/src/test/java/de/learnlib/algorithm/sparse/SparseGrowingAlphabetTest.java
+++ b/algorithms/active/sparse/src/test/java/de/learnlib/algorithm/sparse/SparseGrowingAlphabetTest.java
@@ -1,0 +1,29 @@
+/* Copyright (C) 2013-2026 TU Dortmund University
+ * This file is part of LearnLib <https://learnlib.de>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.learnlib.algorithm.sparse;
+
+import de.learnlib.oracle.MembershipOracle.MealyMembershipOracle;
+import de.learnlib.testsupport.AbstractGrowingAlphabetMealyTest;
+import net.automatalib.alphabet.Alphabet;
+
+public class SparseGrowingAlphabetTest extends AbstractGrowingAlphabetMealyTest<SparseLearner<Character, Character>> {
+
+    @Override
+    protected SparseLearner<Character, Character> getLearner(MealyMembershipOracle<Character, Character> oracle,
+                                                             Alphabet<Character> alphabet) {
+        return new SparseLearner<>(alphabet, oracle);
+    }
+}


### PR DESCRIPTION
This PR extends `GenericSparseLearner` to also implement `SupportsGrowingAlphabet`, allowing it to be integrated into procedural and AAAR scenarios.